### PR TITLE
docs: rename repo to github.repo

### DIFF
--- a/docs/content/1.get-started/2.configuration.md
+++ b/docs/content/1.get-started/2.configuration.md
@@ -37,7 +37,7 @@ The theme design is based on a `primary` color to make it easy to override, you 
 | `layout` | `String` | The layout of your documentation (defaults to `docs`). Can be changed to `readme` to have a one-page doc. |
 | `twitter` | `String` | Twitter username to link in the header. Example: `@nuxt_js`. |
 | `github` | `Object` or `String` | Can be a `String` to act as `github.repo` if no other config is needed. |
-| `repo` | `String` | GitHub repository for the project. This will enable displaying the last version, the releases page, the link at the top and the `Edit this page on GitHub link` on each page. Example: `nuxt/content`. |
+| `github.repo` | `String` | GitHub repository for the project. This will enable displaying the last version, the releases page, the link at the top and the `Edit this page on GitHub link` on each page. Example: `nuxt/content`. |
 | `github.url` | `String` | For GitHub Enterprise, in addition to `github.repo`, you have to assign an url. Example: `https://hostname`. Defaults to `https://github.com`. |
 | `github.apiUrl` | `String` | For GitHub Enterprise, in addition to `github.repo`, you have to assign an api url. Example: `https://hostname/api/v3/repos`. Defaults to `https://api.github.com/repos`. |
 | `github.branch` | `String` | The default branch for the GitHub repository of your project, used in the `Edit this page on GitHub link` on each page (defaults to `main` if it cannot be detected). |


### PR DESCRIPTION
Hey! I think `repo` should be `github.repo` instead as it is referred as such throughout the config page 😋

## Types of changes
- [x] Docs fix (a non-breaking change which fixes an issue)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
