### PR TITLE
fix: article padding for readme layout

### DIFF
--- a/theme/components/templates/AppPage.vue
+++ b/theme/components/templates/AppPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex w-full pt-10 ">
-    <article class="flex-auto min-w-0 px-4 mb-8 sm:px-6 xl:px-8" :class="prose ? 'prose dark:prose-dark' : ''"><slot /></article>
+    <article class="flex-auto min-w-0 px-4 mb-8 sm:px-6" :class="prose ? 'prose dark:prose-dark' : ''"><slot /></article>
     <slot name="toc" />
   </div>
 </template>


### PR DESCRIPTION
Fixing small issue with article padding on `readme` layout