### PR TITLE
fix: title padding hover in releases

### DIFF
--- a/theme/tailwind.config.js
+++ b/theme/tailwind.config.js
@@ -117,11 +117,16 @@ module.exports = ({ nuxt }) => {
                 fontWeight: 'inherit',
                 position: 'relative',
                 code: {
-                  position: 'relative'
+                  border: '1px dashed transparent',
+                  position: 'relative',
+                  zIndex: 0
                 },
                 '&:hover': {
                   borderBottomWidth: 0,
-                  paddingBottom: 0
+                  paddingBottom: 0,
+                  code: {
+                    borderColor: theme('colors.gray.500')
+                  }
                 },
                 '&:before': {
                   content: '""',
@@ -135,6 +140,16 @@ module.exports = ({ nuxt }) => {
                   borderBottomWidth: 1,
                   borderStyle: 'dashed',
                   borderBottomColor: theme('colors.gray.900')
+                },
+                'code:before': {
+                  content: '""',
+                  position: 'absolute',
+                  top: -4,
+                  left: -4,
+                  zIndex: -1,
+                  width: 'calc(100% + 8px)',
+                  height: 'calc(100% + 8px)',
+                  backgroundColor: theme('colors.white')
                 }
               },
               'ul ul, ul ol, ol ul, ol ol': {
@@ -268,7 +283,13 @@ module.exports = ({ nuxt }) => {
                 color: 'inherit',
                 fontWeight: 'inherit',
                 '&:hover': {
-                  borderBottomColor: theme('colors.gray.100')
+                  borderBottomColor: theme('colors.gray.100'),
+                  code: {
+                    borderColor: theme('colors.gray.500')
+                  }
+                },
+                'code:before': {
+                  backgroundColor: theme('colors.gray.900')
                 }
               },
               'figure figcaption': {


### PR DESCRIPTION
close #186 

We probably also need to fix hover on `code` inside title, since it has underline also. 