### PR TITLE
fix: scroll margin in Safari

### DIFF
--- a/theme/assets/css/main.css
+++ b/theme/assets/css/main.css
@@ -1,10 +1,17 @@
 :root {
   --header-height: theme('spacing.14');
+  --scroll-margin-block: calc(var(--header-height) + 2.5rem + 1rem);
 }
 
 @screen md {
   :root {
     --header-height: theme('spacing.18');
+  }
+}
+
+@screen xl {
+  :root {
+    --scroll-margin-block: calc(var(--header-height) + 1rem);
   }
 }
 
@@ -15,7 +22,7 @@ body {
 .nuxt-content {
   @apply break-words;
   & h2 {
-    scroll-margin-block: calc(var(--header-height) + 2.5rem + 1rem);
+    scroll-margin-block: var(--scroll-margin-block);
     /* Style anchor links on headings added by @nuxt/content */
     & > a {
       &::after {
@@ -32,7 +39,7 @@ body {
   }
 
   & h3 {
-    scroll-margin-block: calc(var(--header-height) + 2.5rem + 1rem);
+    scroll-margin-block: var(--scroll-margin-block);
     /* Style anchor links on headings added by @nuxt/content */
     & > a {
       &::after {
@@ -89,7 +96,7 @@ body {
 @screen xl {
   .nuxt-content {
     & h2, & h3 {
-      scroll-margin-block: calc(var(--header-height) + 1rem);
+      scroll-margin-block: var(--scroll-margin-block);
     }
   }
 }

--- a/theme/components/templates/PageToc.vue
+++ b/theme/components/templates/PageToc.vue
@@ -32,6 +32,7 @@
               'text-gray-500 dark:text-gray-400': link.depth === 3 && !(exactActiveLink === link.id || activeLink === link.id),
               'dark:border-primary-500 border-primary-500 dark:text-primary-400 ': link.depth === 3 && (exactActiveLink === link.id || activeLink === link.id)
             }"
+            @click.prevent="scrollToHeading"
           >{{ link.text }}</a>
         </li>
       </ul>
@@ -41,6 +42,8 @@
 </template>
 
 <script>
+import { convertPropToPixels } from '../../utils/dom'
+
 export default {
   props: {
     toc: {
@@ -126,6 +129,14 @@ export default {
           this.activeLink = this.sections[parentIndex].id
         }
       }
+    },
+    scrollToHeading (e) {
+      const hash = e.target.href.split('#').pop()
+      window.location.hash = hash
+      setTimeout(() => {
+        const offset = document.querySelector(`#${hash}`).offsetTop - parseInt(convertPropToPixels('--scroll-margin-block'))
+        window.scrollTo(0, offset)
+      })
     }
   }
 }

--- a/theme/pages/_.vue
+++ b/theme/pages/_.vue
@@ -24,6 +24,7 @@
 import { withoutTrailingSlash } from 'ufo'
 import Vue from 'vue'
 import CopyButton from '../components/molecules/DCopyButton'
+import { convertPropToPixels } from '../utils/dom'
 
 export default {
   name: 'PageSlug',
@@ -87,6 +88,15 @@ export default {
         const component = new Button().$mount()
         block.appendChild(component.$el)
       }
+
+      const headings = [...document.querySelectorAll('.nuxt-content h2'), ...document.querySelectorAll('.nuxt-content h3')]
+      headings.map((heading) => {
+        heading.addEventListener('click', function (e) {
+          e.preventDefault()
+          const offset = heading.offsetTop - parseInt(convertPropToPixels('--scroll-margin-block'))
+          scrollTo(0, offset)
+        })
+      })
     }, 100)
   },
   methods: {

--- a/theme/utils/dom.js
+++ b/theme/utils/dom.js
@@ -1,0 +1,11 @@
+export function convertPropToPixels (prop) {
+  const tempDiv = document.createElement('div')
+  tempDiv.style.position = 'absolute'
+  tempDiv.style.opacity = 0
+  tempDiv.style.height = getComputedStyle(document.documentElement)
+    .getPropertyValue(prop)
+  document.body.appendChild(tempDiv)
+  const pixels = parseInt(getComputedStyle(tempDiv).height)
+  document.body.removeChild(tempDiv)
+  return pixels
+}


### PR DESCRIPTION
Apparently, previous fix still doesn't work in Safari. 

The only hack I currently found is using `padding-top: value` & `margin-top: -value`, but it cause another issue: collapsing margins stopped working, so there's more inconsistent spacing between elements. 

Still looking for another CSS solution. 