### PR TITLE
fix: unclickable headings that contain code

### DIFF
--- a/theme/windi.config.js
+++ b/theme/windi.config.js
@@ -113,11 +113,13 @@ export default {
             },
             'h2 code': {
               color: 'inherit',
-              fontWeight: 'inherit'
+              fontWeight: 'inherit',
+              pointerEvents: 'none'
             },
             'h3 code': {
               color: 'inherit',
-              fontWeight: 'inherit'
+              fontWeight: 'inherit',
+              pointerEvents: 'none'
             },
             'h2 > a, h3 > a': {
               color: 'inherit',
@@ -156,7 +158,8 @@ export default {
                 zIndex: '-1',
                 width: 'calc(100% + 8px)',
                 height: 'calc(100% + 8px)',
-                backgroundColor: theme('colors.white')
+                backgroundColor: theme('colors.white'),
+                pointerEvents: 'none'
               }
             },
             'ol, ul': {


### PR DESCRIPTION
Heading with `code` is unclickable, since the focus is on `code` element not `a` with anchor.