### PR TITLE
fix: use typescript-build as a devDependency

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -9,7 +9,7 @@ export default withDocus({
   /**
    * Modules
    */
-  buildModules: ['vue-plausible'],
+  buildModules: ['vue-plausible', '@nuxt/typescript-build'],
   /**
    * Modules config
    */

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@docsearch/js": "^1.0.0-alpha.28",
     "@lokidb/loki": "^2.1.0",
     "@nuxt/image": "^0.4.8",
-    "@nuxt/typescript-build": "^2.1.0",
     "@nuxtjs/color-mode": "^2.0.5",
     "@nuxtjs/composition-api": "0.23.3",
     "@nuxtjs/proxy": "^2.1.0",
@@ -129,7 +128,8 @@
     "eslint-plugin-prettier": "^3.4.0",
     "prettier": "^2.3.0",
     "standard-version": "^9.3.0",
-    "terser": "^5.7.0"
+    "terser": "^5.7.0",
+    "@nuxt/typescript-build": "^2.1.0"
   },
   "peerDependencies": {
     "vuex": "^3.6.2"

--- a/playground/nuxt.config.js
+++ b/playground/nuxt.config.js
@@ -5,5 +5,6 @@ export default withDocus({
   rootDir: __dirname,
   windicss: {
     root: resolve(__dirname, '..')
-  }
+  },
+  buildModules: ['@nuxt/typescript-build']
 })

--- a/src/app/nuxt.config.ts
+++ b/src/app/nuxt.config.ts
@@ -48,7 +48,6 @@ export default nuxtConfig({
   buildModules: [
     // Dependencies
     'nuxt-vite',
-    '@nuxt/typescript-build',
     '@nuxtjs/pwa',
     '@nuxt/image',
     '@nuxtjs/composition-api/module',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

While during development (in docus repo) it is needed to use `@nuxt/typescript-build`, an end-user does not usually needs typescript. All app is already converted to pure js by siroc/mkdist.

Partially fixes #301


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
