### PR TITLE
feat: handle boolean attributes

### DIFF
--- a/src/core/parser/markdown/directive/remark-directive/from-markdown.ts
+++ b/src/core/parser/markdown/directive/remark-directive/from-markdown.ts
@@ -29,6 +29,12 @@ const exit = {
   directiveContainerLabel: exitContainerLabel,
   directiveContainerName: exitName,
 
+  directiveContainerAttributeInitializerMarker() {
+    // If an attribute name follows by `=` it should be treat as string
+    const attributes = this.getData('directiveAttributes')
+    attributes[attributes.length - 1][1] = ''
+  },
+
   directiveLeaf: exitToken,
   directiveLeafAttributeClassValue: exitAttributeClassValue,
   directiveLeafAttributeIdValue: exitAttributeIdValue,
@@ -144,7 +150,9 @@ function exitAttributeValue(token: Token) {
 function exitAttributeName(token: Token) {
   // Attribute names in CommonMark are significantly limited, so character
   // references can’t exist.
-  this.getData('directiveAttributes').push([this.sliceSerialize(token), ''])
+
+  // Use `true` as attrubute default value to solve issue of attributes without value (example `:block{attr1 attr2}`)
+  this.getData('directiveAttributes').push([this.sliceSerialize(token), true])
 }
 
 function exitAttributes() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
This PR adds improve usability and reduce possible mistakes of using boolean attributes.
With these changes boolean attributes can be used just by defining in directive attributes list and users can omit `true` value

Usage:

```
::video-player{loop playsinline controls}
...
::
```

Previously it should be used like this

```
::video-player{loop=true playsinline=true controls=true}
...
::
``` 

Originally reported in https://github.com/nuxtlabs/docus/pull/400#issuecomment-858356526


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
