### PR TITLE
fix(core): use ignore pattern based on driver path

### DIFF
--- a/src/core/storage/driver.ts
+++ b/src/core/storage/driver.ts
@@ -49,7 +49,7 @@ function sortItemKeys(keys: string[]) {
 export const docusDriver = defineDriver((options: DriverOptions) => {
   // force ignore node_modules and .git and files with `_` prefix
   if (options.ignore) {
-    options.ignore.push('**/node_modules/**', '**/.git/**', '**/_**/**')
+    options.ignore.push('**/node_modules/**', '**/.git/**', join(options.base, '**/_**/**'))
   }
 
   const { insert, items } = useDB()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
`unstroage` uses full path of contents to evaluate ignore pattern therefore if one of parent directories starts with underscore, Docus will not parse and render contents at all.
Using driver base path in ignore pattern ensures that underscore ignoring only applies to contents.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
