### PR TITLE
fix: add fixed width to mobile aside

### DIFF
--- a/src/defaultTheme/components/organisms/app/AppAside.vue
+++ b/src/defaultTheme/components/organisms/app/AppAside.vue
@@ -15,7 +15,7 @@
 
       <!-- Mobile aside -->
       <Transition name="slide-from-left-to-left">
-        <AsideNavigation v-show="$menu.visible.value" class="d-border border-r" />
+        <AsideNavigation v-show="$menu.visible.value" class="d-border border-r !w-base" />
       </Transition>
     </div>
   </aside>

--- a/src/defaultTheme/windi.config.ts
+++ b/src/defaultTheme/windi.config.ts
@@ -65,6 +65,7 @@ export default defineConfig({
         }
       },
       spacing: {
+        base: '320px',
         header: 'var(--header-height)',
         18: '4.5rem',
         46: '11.5rem',


### PR DESCRIPTION
Adds fixed width to mobile aside to prevent changing of width when collapsing headings

