### PR TITLE
:bug: (prose-code-inline) allow line break

### DIFF
--- a/src/defaultTheme/components/atoms/prose/ProseCodeInline.vue
+++ b/src/defaultTheme/components/atoms/prose/ProseCodeInline.vue
@@ -6,7 +6,7 @@
 
 <style lang="postcss" scoped>
 code {
-  @apply font-normal text-sm py-3px px-6px whitespace-nowrap rounded-md d-prose-code-inline-bg;
+  @apply font-normal text-sm py-3px px-6px rounded-md d-prose-code-inline-bg;
 }
 
 a code {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1385263/123706448-956bcb00-d868-11eb-9b77-d3be6bce06fe.png)

Page:
https://admiring-heyrovsky-27a7cf.netlify.app/docs/configuration-glossary/configuration-css

Reported from the @Atinux Slack message.

I've tried fixing this via browser console, removing that:
https://github.com/nuxtlabs/docus/blob/faef8fb688322ec293d6e4c8fe820d626444b30c/src/defaultTheme/components/atoms/prose/ProseCodeInline.vue#L9

Seem not to break neither the line-wrapping occurrences and the non line-wrapping ones.

@bdrtsky; could you review this to be sure it does not have side effects ?