### PR TITLE
fix: restrict inline syntax

### DIFF
--- a/src/core/parser/markdown/directive/micromark-directive/tokenize-directive-inline.ts
+++ b/src/core/parser/markdown/directive/micromark-directive/tokenize-directive-inline.ts
@@ -22,7 +22,11 @@ function tokenize(effects: Effects, ok: Okay, nok: NotOkay) {
     /* istanbul ignore if - handled by mm */
     if (code !== 58 /* `:` */) throw new Error('expected `:`')
 
-    if (self.previous !== null && !markdownLineEndingOrSpace(self.previous)) {
+    if (
+      self.previous !== null &&
+      !markdownLineEndingOrSpace(self.previous) &&
+      ![Codes.openingSquareBracket].includes(self.previous)
+    ) {
       return nok
     }
 
@@ -74,7 +78,7 @@ function tokenize(effects: Effects, ok: Okay, nok: NotOkay) {
   }
 
   function exit(code: number) {
-    if (!markdownLineEndingOrSpace(code) && code !== null) {
+    if (!markdownLineEndingOrSpace(code) && code !== null && ![Codes.closingSquareBracket].includes(code)) {
       return nok
     }
     effects.exit('directiveText')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Inline Components should start with whitespace and and end with whitespace.

resolves nuxtlabs/nuxtjs.org-board#92

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
