### PR TITLE
fix(pkg): expose utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "layouts",
     "pages",
     "plugins",
+    "utils",
     "module.ts",
     "nuxt.config.ts",
     "theme.config.ts",


### PR DESCRIPTION
Should resolve #615

In general, i would suggest to use [npmignore](https://npm.github.io/publishing-pkgs-docs/publishing/the-npmignore-file.html) if most of the repo is to be published such as a theme or (much better) use `src/` or `app/` or `theme/` directory inside theme repo. Because it is easy to forget including new top level dirs and files.