### PR TITLE
fix: update nuxi command

### DIFF
--- a/.docs/content/0.index.md
+++ b/.docs/content/0.index.md
@@ -15,7 +15,7 @@ cta:
 secondary:
   - Open on GitHub →
   - https://github.com/nuxtlabs/docus
-snippet: npx nuxi init -t themes/docus
+snippet: npx nuxi init -t nuxt-themes/docus
 ---
 
 #title


### PR DESCRIPTION
The nuxi command was trying to resolve `https://github.com/themes/docus` which does not exist and could even lead to a potential security risk, as bad actors could use the nuxt name and install malware in the process.