### PR TITLE
fix: toc correctly reflects headings in a viewport

### DIFF
--- a/composables/useScrollspy.ts
+++ b/composables/useScrollspy.ts
@@ -23,7 +23,7 @@ export const useScrollspy = () => {
 
   watch(visibleHeadings, (val, oldVal) => {
     if (val.length === 0) { activeHeadings.value = oldVal } else { activeHeadings.value = val }
-  })
+  }, { deep: true })
 
   // Create intersection observer
   onBeforeMount(() => (observer.value = new IntersectionObserver(observerCallback)))


### PR DESCRIPTION
### Fix 

This fixes #700 by adding deep watch option in `useScrollspy.ts`:

from 
```ts
watch(visibleHeadings, (val, oldVal) => {
    if (val.length === 0) { activeHeadings.value = oldVal } else { activeHeadings.value = val }
})
```

to 
```ts
watch(visibleHeadings, (val, oldVal) => {
    if (val.length === 0) { activeHeadings.value = oldVal } else { activeHeadings.value = val }
}, { deep: true })
```

###  Problem Previously

`useScrollspy.ts` 

While visibleHeadings were correctly updated when it came into a viewport (by chekcing if `entry.isIntersecting` using `IntersectionObserver` API), the watch function below did not updated activeHeadings in some circumstances (like when there were no activeHeadings in a viewport)

I tried adding deep option to the watch function and it fixed the problem (might be bad for performance?)
<details><summary>Note</summary>
<p>
It's my first time contributing to open source. Hope I'm not making any mistakes haha
</p>
</details>
