### PR TITLE
fix: use aside.exclude for mobile aside

### DIFF
--- a/components/app/AppHeaderDialog.vue
+++ b/components/app/AppHeaderDialog.vue
@@ -4,7 +4,7 @@ import ThemeSelect from './ThemeSelect.vue'
 const { navigation } = useContent()
 const docus = useDocus()
 
-const filtered = computed(() => docus.value.header?.exclude || [])
+const filtered = computed(() => docus.value.aside?.exclude || [])
 
 const links = computed(() => {
   return (navigation.value || []).filter((item: any) => {


### PR DESCRIPTION
`components/app/AppHeaderDialog.vue` component uses `header.exclude` to filter the navigation to display aside on mobile devices, which is actually aside but filtering with `header.exclude` causes filtering aside links

