### PR TITLE
Update 'icons' key in Complete app.config.ts example to 'iconLinks'

### DIFF
--- a/.docs/content/1.introduction/4.configuration.md
+++ b/.docs/content/1.introduction/4.configuration.md
@@ -46,7 +46,7 @@ export default defineAppConfig({
         text: 'Powered by Docus',
         href: 'https://docus.com',
       },
-      icons: [
+      iconLinks: [
         {
           label: 'NuxtJS',
           href: 'https://nuxtjs.org',


### PR DESCRIPTION
When 'icons' was renamed to 'iconLinks' here https://github.com/nuxt-themes/docus/commit/be04cc9d6dcd8a769029bdd295152e11a29f6755 the example Complete app.config.ts configuration wasn't updated.