### PR TITLE
feat: collapsed state fine-tuning 

### DIFF
--- a/components/docs/DocsAsideTree.vue
+++ b/components/docs/DocsAsideTree.vue
@@ -46,6 +46,9 @@ const isCollapsed = (link) => {
       return collapsedMap.value[link._path]
     }
 
+    // Check if aside.collapsed has been set in YML
+    if(link.aside?.hasOwnProperty('collapsed')) { return link.aside.collapsed }
+
     // Return value grabbed from the link
     if (link?.collapsed) { return link?.collapsed }
 

--- a/components/docs/DocsAsideTree.vue
+++ b/components/docs/DocsAsideTree.vue
@@ -47,7 +47,7 @@ const isCollapsed = (link) => {
     }
 
     // Check if aside.collapsed has been set in YML
-    if(link.aside?.hasOwnProperty('collapsed')) { return link.aside.collapsed }
+    if (link.aside?.hasOwnProperty('collapsed')) { return link.aside.collapsed }
 
     // Return value grabbed from the link
     if (link?.collapsed) { return link?.collapsed }


### PR DESCRIPTION
If you set the following in a _dir.yml the dir should be collapsed (or not) according to your choice.
```
aside:
    collapsed: true/false
```

This way, you can fine-tune the collapsed state of each dir in the aside tree.

Resolves #743