### PR TITLE
chore(bump): bump to 2.0.0

### DIFF
--- a/.docs/content/0.index.md
+++ b/.docs/content/0.index.md
@@ -32,7 +32,7 @@ Write pages in [Markdown](https://content.nuxtjs.org), use [Vue](https://vuejs.o
   - Start from a `README`, scale to a framework documentation
   - Navigation and Table of Contents generation
   - Fully configurable [design system](https://github.com/nuxt-themes/tokens)
-  - Leverages [**Typography**](https://typography.nuxt.space/) and [**Elements**](https://elements.nuxt.dev)
+  - Leverages [**Typography**](https://typography.nuxt.space/) and [**Elements**](https://elements.nuxt.space)
   - Used on [Content Documentation](https://content.nuxtjs.org)
   ::
 ::

--- a/.docs/content/1.introduction/4.configuration.md
+++ b/.docs/content/1.introduction/4.configuration.md
@@ -8,63 +8,59 @@ Learn how to configure Docus.
 export default defineAppConfig({
   docus: {
     title: 'Docus',
-    description: 'My Docus Project',
-    url: 'http://docus.dev'
+    description: 'My Docus Project'
   }
 })
 ```
 
-```ts [Complete app.config.ts]
+```ts [Default app.config.ts]
 export default defineAppConfig({
   docus: {
     title: 'Docus',
-    description: 'My Docus Project',
-    url: 'http://docus.dev',
-    image: '/social-card-preview.png',
+    titleTemplate: '',
+    description: 'The best place to start your documentation.',
+    image: 'https://user-images.githubusercontent.com/904724/185365452-87b7ca7b-6030-4813-a2db-5e65c785bf88.png',
     socials: {
-      twitter: '@docus_',
-      github: 'nuxtlabs/docus',
-    },
-    github: {
-      root: 'content',
-      edit: true,
-      contributors: false
+      twitter: '',
+      github: '',
+      facebook: '',
+      instagram: '',
+      youtube: '',
+      medium: ''
     },
     layout: 'default',
-    aside: {
-      level: 1,
-      filter: [],
-    },
     header: {
-      title: false,
-      logo: true,
-      showLinkIcon: false
+      title: '',
+      logo: false,
+      showLinkIcon: false,
+      fluid: true,
+      exclude: []
+    },
+    main: {
+      fluid: true,
+      padded: true
+    },
+    aside: {
+      level: 0,
+      collapsed: false,
+      exclude: []
     },
     footer: {
       credits: {
         icon: 'IconDocus',
         text: 'Powered by Docus',
-        href: 'https://docus.dev',
+        href: 'https://docus.dev'
       },
-      textLinks: [
-        {
-          text: 'NuxtJS',
-          href: 'https://nuxtjs.org',
-          target: '_blank'
-        }
-      ],
-      iconLinks: [
-        {
-          label: 'NuxtJS',
-          href: 'https://nuxtjs.org',
-          component: 'IconNuxtLabs',
-        },
-        {
-          label: 'Vue Telescope',
-          href: 'https://vuetelescope.com',
-          component: 'IconVueTelescope',
-        },
-      ],
+      textLinks: [],
+      iconLinks: [],
+      fluid: true
+    },
+    github: {
+      dir: '',
+      branch: '',
+      repo: '',
+      owner: '',
+      edit: false
     }
   }
 })
@@ -74,11 +70,10 @@ export default defineAppConfig({
 
 | **Key**                      | **Type**   | **Default**      | **Description**                                                     |
 | ---------------------------- | ---------- | ---------------- | ------------------------------------------------------------------- |
-| `title`                      | `string`   | Docus            | Website title                                                       |
-| `titleTemplate`              | `string`   | Docus            | Website title template                                              |
-| `description`                | `string`   | My Docus Project | Website description                                                 |
-| `url`                        | `string`   |                  | Website URL                                                         |
-| `layout`                     | `string`   | default          | Fallback layout to use (supports `default` or `docs`)               |
+| `title`                      | `string`   | `'Docus'`            | Website title                                                       |
+| `titleTemplate`              | `string`   | `'%s · ${config.title}'`            | Website title template                                              |
+| `description`                | `string`   | `'My Docus Project'` | Website description                                                 |
+| `layout`                     | `string`   | `'default'`          | Fallback layout to use (supports `default` or `docs`)               |
 | **Socials**                  |            |                  |                                                                     |
 | `socials`                    | `object`   | `{}`             | Social links                                                        |
 | `socials.github`             | `string`   |                  | The repository to use on GitHub links                               |
@@ -93,22 +88,23 @@ export default defineAppConfig({
 | `socials.[social].href`      | `string`   |                  | A link to use for the social                                        |
 | **Header**                   |            |                  |                                                                     |
 | `header`                     | `object`   |                  | Header configuration                                                |
+| `header.fluid`               | `boolean`  | `true`           | Make header `Container` fluid                                       |
 | `header.logo`                | `boolean`  |                  | Whether or not to use `Logo.vue` as the header logo                 |
 | `header.title`               | `string`   |                  | If set to a string, will be used in the header                      |
 | `header.showLinkIcon`        | `boolean`  |                  | If set to `true` links icons will show in the header                |
 | `header.exclude`             | `string[]` |                  | An array of path to exclude out from the header navigation          |
-| `header.fluid`               | `boolean`  | `true`           | Make header `Container` fluid                                       |
 | **Main**                     |            |                  |                                                                     |
 | `main`                       | `object`   |                  | Main configuration                                                  |
 | `main.fluid`                 | `boolean`  | `true`           | Make main content `Container` fluid                                 |
 | `main.padded`                | `boolean`  | `true`           | Make main content `Container` padded                                |
 | **Aside**                    |            |                  |                                                                     |
 | `aside`                      | `object`   |                  | Aside configuration                                                 |
-| `aside.level`                | `string`   | 0                | Aside base level of nesting                                         |
+| `aside.level`                | `string`   | `0`               | Aside base level of nesting                                         |
 | `aside.collapsed`            | `boolean`  |                  | Will be used as default value for collapsible navigation categories |
 | `aside.exclude`              | `string[]` |                  | An array of path to exclude out from the aside navigation           |
 | **Footer**                   |            |                  |                                                                     |
 | `footer`                     | `object`   |                  | Footer configuration                                                |
+| `footer.fluid`               | `boolean`  | `true`           | Make footer `Container` fluid                                       |
 | `footer.credits`             | `object`   |                  | An object defining the bottom left credits                          |
 | `footer.credits.icon`        | `object`   |                  | The icon to use for the credits                                     |
 | `footer.credits.text`        | `object`   |                  | The text to use for the credits                                     |
@@ -120,7 +116,6 @@ export default defineAppConfig({
 | `footer.iconLinks[0].label`  | `string`   |                  | A label to use for the icon                                         |
 | `footer.iconLinks[0].href`   | `string`   |                  | A link to use for the icon                                          |
 | `footer.iconLinks[0].icon`   | `string`   |                  | The icon to use (can be a component name)                           |
-| `footer.fluid`               | `boolean`  | `true`           | Make footer `Container` fluid                                       |
 | **GitHub**                   |            |                  |                                                                     |
 | `github`                     | `object`   | `false`          | GitHub integration configuration                                    |
 | `github.dir`                 | `string`   |                  | Directory containing the files to be edited                         |

--- a/.docs/nuxt.config.ts
+++ b/.docs/nuxt.config.ts
@@ -7,7 +7,7 @@ export default defineNuxtConfig({
       }
     }
   },
-  modules: ['nuxt-plausible'],
+  modules: ['@nuxtjs/plausible'],
   typescript: {
     includeWorkspace: true
   }

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,11 +1,9 @@
 export default defineAppConfig({
   docus: {
     title: 'Docus',
-
+    titleTemplate: '%s - Teub',
     description: 'The best place to start your documentation.',
-
     image: 'https://user-images.githubusercontent.com/904724/185365452-87b7ca7b-6030-4813-a2db-5e65c785bf88.png',
-
     socials: {
       twitter: '',
       github: '',
@@ -14,23 +12,23 @@ export default defineAppConfig({
       youtube: '',
       medium: ''
     },
-
     layout: 'default',
-
     header: {
       title: '',
       logo: false,
       showLinkIcon: false,
-      fluid: false,
+      fluid: true,
       exclude: []
     },
-
+    main: {
+      fluid: true,
+      padded: true
+    },
     aside: {
       level: 0,
       collapsed: false,
       exclude: []
     },
-
     footer: {
       credits: {
         icon: 'IconDocus',
@@ -39,14 +37,13 @@ export default defineAppConfig({
       },
       textLinks: [],
       iconLinks: [],
-      fluid: false
+      fluid: true
     },
-
     github: {
-      dir: undefined,
-      branch: undefined,
-      repo: undefined,
-      owner: undefined,
+      dir: '',
+      branch: '',
+      repo: '',
+      owner: '',
       edit: false
     }
   }

--- a/app/module.ts
+++ b/app/module.ts
@@ -1,9 +1,4 @@
-import { fileURLToPath } from 'url'
-import { addPlugin, defineNuxtModule } from '@nuxt/kit'
-import { resolve } from 'pathe'
-
-const themeDir = fileURLToPath(new URL('./', import.meta.url))
-const resolveThemeDir = (path: string) => resolve(themeDir, path)
+import { addPlugin, defineNuxtModule, createResolver } from '@nuxt/kit'
 
 export default defineNuxtModule({
   meta: {
@@ -15,10 +10,11 @@ export default defineNuxtModule({
     },
     configKey: 'docus'
   },
-  setup(_, nuxt) {
+  setup (_, nuxt) {
+    const { resolve } = createResolver(import.meta.url)
     if (nuxt.options?.runtimeConfig?.public?.algolia?.docSearch) {
       addPlugin({
-        src: resolveThemeDir('integrations/docsearch.ts')
+        src: resolve('integrations/docsearch')
       })
     }
   }

--- a/components/app/AppLayout.vue
+++ b/components/app/AppLayout.vue
@@ -19,8 +19,8 @@ useContentHead(config.value as any)
 <template>
   <div>
     <AppLoadingBar />
-    <AppHeader v-if="Object.keys(config?.header).length" />
+    <AppHeader />
     <slot />
-    <AppFooter v-if="Object.keys(config?.footer).length" />
+    <AppFooter />
   </div>
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,8 +4,6 @@ import { version } from './package.json'
 
 logger.success(`Using Docus v${version}`)
 
-process.env.NUXT_INLINE_STYLES = 'true'
-
 const { resolve } = createResolver(import.meta.url)
 
 // That allows to overwrite these dependencies paths via `.env` for local development
@@ -51,9 +49,6 @@ export default defineNuxtConfig({
       global: true
     }
   ],
-  pinceau: {
-    studio: true
-  },
   content: {
     documentDriven: true,
     highlight: {

--- a/nuxt.schema.ts
+++ b/nuxt.schema.ts
@@ -154,7 +154,7 @@ export default defineNuxtSchema({
         /**
          * Makes the content of the header fluid.
          */
-        fluid: false
+        fluid: true
       },
 
       /**
@@ -166,7 +166,7 @@ export default defineNuxtSchema({
         /**
          * Makes the content of the main container fluid.
          */
-        fluid: false,
+        fluid: true,
         /**
          * Makes the content of the main container padded.
          */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt-themes/docus",
-  "version": "1.6.3",
+  "version": "2.0.0",
   "type": "module",
   "main": "./nuxt.config.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
     "@nuxtjs/plausible": "^0.2.0",
     "eslint": "^8.33.0",
-    "nuxt": "3.1.1",
+    "nuxt": "^3.1.1",
     "release-it": "^15.6.0",
     "typescript": "^4.9.5",
     "vue": "^3.2.45"

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "@docsearch/js": "^3.3.2",
     "@nuxtjs/algolia": "^1.5.0",
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
+    "@nuxtjs/plausible": "^0.2.0",
     "eslint": "^8.33.0",
     "nuxt": "3.1.1",
-    "nuxt-plausible": "^0.1.2",
     "release-it": "^15.6.0",
     "typescript": "^4.9.5",
     "vue": "^3.2.45"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ specifiers:
   '@nuxtjs/plausible': ^0.2.0
   '@vueuse/nuxt': ^9.12.0
   eslint: ^8.33.0
-  nuxt: 3.1.1
+  nuxt: ^3.1.1
   release-it: ^15.6.0
   typescript: ^4.9.5
   vue: ^3.2.45
@@ -541,8 +541,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/android-arm/0.17.4:
-    resolution: {integrity: sha512-R9GCe2xl2XDSc2XbQB63mFiFXHIVkOP+ltIxICKXqUPrFX97z6Z7vONCLQM1pSOLGqfLrGi3B7nbhxmFY/fomg==}
+  /@esbuild/android-arm/0.17.5:
+    resolution: {integrity: sha512-crmPUzgCmF+qZXfl1YkiFoUta2XAfixR1tEnr/gXIixE+WL8Z0BGqfydP5oox0EUOgQMMRgtATtakyAcClQVqQ==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -557,8 +557,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/android-arm64/0.17.4:
-    resolution: {integrity: sha512-91VwDrl4EpxBCiG6h2LZZEkuNvVZYJkv2T9gyLG/mhGG1qrM7i5SwUcg/hlSPnL/4hDT0TFcF35/XMGSn0bemg==}
+  /@esbuild/android-arm64/0.17.5:
+    resolution: {integrity: sha512-KHWkDqYAMmKZjY4RAN1PR96q6UOtfkWlTS8uEwWxdLtkRt/0F/csUhXIrVfaSIFxnscIBMPynGfhsMwQDRIBQw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -573,8 +573,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/android-x64/0.17.4:
-    resolution: {integrity: sha512-mGSqhEPL7029XL7QHNPxPs15JVa02hvZvysUcyMP9UXdGFwncl2WU0bqx+Ysgzd+WAbv8rfNa73QveOxAnAM2w==}
+  /@esbuild/android-x64/0.17.5:
+    resolution: {integrity: sha512-8fI/AnIdmWz/+1iza2WrCw8kwXK9wZp/yZY/iS8ioC+U37yJCeppi9EHY05ewJKN64ASoBIseufZROtcFnX5GA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -589,8 +589,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/darwin-arm64/0.17.4:
-    resolution: {integrity: sha512-tTyJRM9dHvlMPt1KrBFVB5OW1kXOsRNvAPtbzoKazd5RhD5/wKlXk1qR2MpaZRYwf4WDMadt0Pv0GwxB41CVow==}
+  /@esbuild/darwin-arm64/0.17.5:
+    resolution: {integrity: sha512-EAvaoyIySV6Iif3NQCglUNpnMfHSUgC5ugt2efl3+QDntucJe5spn0udNZjTgNi6tKVqSceOw9tQ32liNZc1Xw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -605,8 +605,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/darwin-x64/0.17.4:
-    resolution: {integrity: sha512-phQuC2Imrb3TjOJwLN8EO50nb2FHe8Ew0OwgZDH1SV6asIPGudnwTQtighDF2EAYlXChLoMJwqjAp4vAaACq6w==}
+  /@esbuild/darwin-x64/0.17.5:
+    resolution: {integrity: sha512-ha7QCJh1fuSwwCgoegfdaljowwWozwTDjBgjD3++WAy/qwee5uUi1gvOg2WENJC6EUyHBOkcd3YmLDYSZ2TPPA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -621,8 +621,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/freebsd-arm64/0.17.4:
-    resolution: {integrity: sha512-oH6JUZkocgmjzzYaP5juERLpJQSwazdjZrTPgLRmAU2bzJ688x0vfMB/WTv4r58RiecdHvXOPC46VtsMy/mepg==}
+  /@esbuild/freebsd-arm64/0.17.5:
+    resolution: {integrity: sha512-VbdXJkn2aI2pQ/wxNEjEcnEDwPpxt3CWWMFYmO7CcdFBoOsABRy2W8F3kjbF9F/pecEUDcI3b5i2w+By4VQFPg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -637,8 +637,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/freebsd-x64/0.17.4:
-    resolution: {integrity: sha512-U4iWGn/9TrAfpAdfd56eO0pRxIgb0a8Wj9jClrhT8hvZnOnS4dfMPW7o4fn15D/KqoiVYHRm43jjBaTt3g/2KA==}
+  /@esbuild/freebsd-x64/0.17.5:
+    resolution: {integrity: sha512-olgGYND1/XnnWxwhjtY3/ryjOG/M4WfcA6XH8dBTH1cxMeBemMODXSFhkw71Kf4TeZFFTN25YOomaNh0vq2iXg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -653,8 +653,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-arm/0.17.4:
-    resolution: {integrity: sha512-S2s9xWTGMTa/fG5EyMGDeL0wrWVgOSQcNddJWgu6rG1NCSXJHs76ZP9AsxjB3f2nZow9fWOyApklIgiTGZKhiw==}
+  /@esbuild/linux-arm/0.17.5:
+    resolution: {integrity: sha512-YBdCyQwA3OQupi6W2/WO4FnI+NWFWe79cZEtlbqSESOHEg7a73htBIRiE6uHPQe7Yp5E4aALv+JxkRLGEUL7tw==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -669,8 +669,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-arm64/0.17.4:
-    resolution: {integrity: sha512-UkGfQvYlwOaeYJzZG4cLV0hCASzQZnKNktRXUo3/BMZvdau40AOz9GzmGA063n1piq6VrFFh43apRDQx8hMP2w==}
+  /@esbuild/linux-arm64/0.17.5:
+    resolution: {integrity: sha512-8a0bqSwu3OlLCfu2FBbDNgQyBYdPJh1B9PvNX7jMaKGC9/KopgHs37t+pQqeMLzcyRqG6z55IGNQAMSlCpBuqg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -685,8 +685,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-ia32/0.17.4:
-    resolution: {integrity: sha512-3lqFi4VFo/Vwvn77FZXeLd0ctolIJH/uXkH3yNgEk89Eh6D3XXAC9/iTPEzeEpsNE5IqGIsFa5Z0iPeOh25IyA==}
+  /@esbuild/linux-ia32/0.17.5:
+    resolution: {integrity: sha512-uCwm1r/+NdP7vndctgq3PoZrnmhmnecWAr114GWMRwg2QMFFX+kIWnp7IO220/JLgnXK/jP7VKAFBGmeOYBQYQ==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -701,8 +701,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-loong64/0.17.4:
-    resolution: {integrity: sha512-HqpWZkVslDHIwdQ9D+gk7NuAulgQvRxF9no54ut/M55KEb3mi7sQS3GwpPJzSyzzP0UkjQVN7/tbk88/CaX4EQ==}
+  /@esbuild/linux-loong64/0.17.5:
+    resolution: {integrity: sha512-3YxhSBl5Sb6TtBjJu+HP93poBruFzgXmf3PVfIe4xOXMj1XpxboYZyw3W8BhoX/uwxzZz4K1I99jTE/5cgDT1g==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -717,8 +717,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-mips64el/0.17.4:
-    resolution: {integrity: sha512-d/nMCKKh/SVDbqR9ju+b78vOr0tNXtfBjcp5vfHONCCOAL9ad8gN9dC/u+UnH939pz7wO+0u/x9y1MaZcb/lKA==}
+  /@esbuild/linux-mips64el/0.17.5:
+    resolution: {integrity: sha512-Hy5Z0YVWyYHdtQ5mfmfp8LdhVwGbwVuq8mHzLqrG16BaMgEmit2xKO+iDakHs+OetEx0EN/2mUzDdfdktI+Nmg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -733,8 +733,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-ppc64/0.17.4:
-    resolution: {integrity: sha512-lOD9p2dmjZcNiTU+sGe9Nn6G3aYw3k0HBJies1PU0j5IGfp6tdKOQ6mzfACRFCqXjnBuTqK7eTYpwx09O5LLfg==}
+  /@esbuild/linux-ppc64/0.17.5:
+    resolution: {integrity: sha512-5dbQvBLbU/Y3Q4ABc9gi23hww1mQcM7KZ9KBqabB7qhJswYMf8WrDDOSw3gdf3p+ffmijMd28mfVMvFucuECyg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -749,8 +749,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-riscv64/0.17.4:
-    resolution: {integrity: sha512-mTGnwWwVshAjGsd8rP+K6583cPDgxOunsqqldEYij7T5/ysluMHKqUIT4TJHfrDFadUwrghAL6QjER4FeqQXoA==}
+  /@esbuild/linux-riscv64/0.17.5:
+    resolution: {integrity: sha512-fp/KUB/ZPzEWGTEUgz9wIAKCqu7CjH1GqXUO2WJdik1UNBQ7Xzw7myIajpxztE4Csb9504ERiFMxZg5KZ6HlZQ==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -765,8 +765,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-s390x/0.17.4:
-    resolution: {integrity: sha512-AQYuUGp50XM29/N/dehADxvc2bUqDcoqrVuijop1Wv72SyxT6dDB9wjUxuPZm2HwIM876UoNNBMVd+iX/UTKVQ==}
+  /@esbuild/linux-s390x/0.17.5:
+    resolution: {integrity: sha512-kRV3yw19YDqHTp8SfHXfObUFXlaiiw4o2lvT1XjsPZ++22GqZwSsYWJLjMi1Sl7j9qDlDUduWDze/nQx0d6Lzw==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -781,8 +781,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-x64/0.17.4:
-    resolution: {integrity: sha512-+AsFBwKgQuhV2shfGgA9YloxLDVjXgUEWZum7glR5lLmV94IThu/u2JZGxTgjYby6kyXEx8lKOqP5rTEVBR0Rw==}
+  /@esbuild/linux-x64/0.17.5:
+    resolution: {integrity: sha512-vnxuhh9e4pbtABNLbT2ANW4uwQ/zvcHRCm1JxaYkzSehugoFd5iXyC4ci1nhXU13mxEwCnrnTIiiSGwa/uAF1g==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -797,8 +797,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/netbsd-x64/0.17.4:
-    resolution: {integrity: sha512-zD1TKYX9553OiLS/qkXPMlWoELYkH/VkzRYNKEU+GwFiqkq0SuxsKnsCg5UCdxN3cqd+1KZ8SS3R+WG/Hxy2jQ==}
+  /@esbuild/netbsd-x64/0.17.5:
+    resolution: {integrity: sha512-cigBpdiSx/vPy7doUyImsQQBnBjV5f1M99ZUlaJckDAJjgXWl6y9W17FIfJTy8TxosEF6MXq+fpLsitMGts2nA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -813,8 +813,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/openbsd-x64/0.17.4:
-    resolution: {integrity: sha512-PY1NjEsLRhPEFFg1AV0/4Or/gR+q2dOb9s5rXcPuCjyHRzbt8vnHJl3vYj+641TgWZzTFmSUnZbzs1zwTzjeqw==}
+  /@esbuild/openbsd-x64/0.17.5:
+    resolution: {integrity: sha512-VdqRqPVIjjZfkf40LrqOaVuhw9EQiAZ/GNCSM2UplDkaIzYVsSnycxcFfAnHdWI8Gyt6dO15KHikbpxwx+xHbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -829,8 +829,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/sunos-x64/0.17.4:
-    resolution: {integrity: sha512-B3Z7s8QZQW9tKGleMRXvVmwwLPAUoDCHs4WZ2ElVMWiortLJFowU1NjAhXOKjDgC7o9ByeVcwyOlJ+F2r6ZgmQ==}
+  /@esbuild/sunos-x64/0.17.5:
+    resolution: {integrity: sha512-ItxPaJ3MBLtI4nK+mALLEoUs6amxsx+J1ibnfcYMkqaCqHST1AkF4aENpBehty3czqw64r/XqL+W9WqU6kc2Qw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -845,8 +845,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-arm64/0.17.4:
-    resolution: {integrity: sha512-0HCu8R3mY/H5V7N6kdlsJkvrT591bO/oRZy8ztF1dhgNU5xD5tAh5bKByT1UjTGjp/VVBsl1PDQ3L18SfvtnBQ==}
+  /@esbuild/win32-arm64/0.17.5:
+    resolution: {integrity: sha512-4u2Q6qsJTYNFdS9zHoAi80spzf78C16m2wla4eJPh4kSbRv+BpXIfl6TmBSWupD8e47B1NrTfrOlEuco7mYQtg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -861,8 +861,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-ia32/0.17.4:
-    resolution: {integrity: sha512-VUjhVDQycse1gLbe06pC/uaA0M+piQXJpdpNdhg8sPmeIZZqu5xPoGWVCmcsOO2gaM2cywuTYTHkXRozo3/Nkg==}
+  /@esbuild/win32-ia32/0.17.5:
+    resolution: {integrity: sha512-KYlm+Xu9TXsfTWAcocLuISRtqxKp/Y9ZBVg6CEEj0O5J9mn7YvBKzAszo2j1ndyzUPk+op+Tie2PJeN+BnXGqQ==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -877,8 +877,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-x64/0.17.4:
-    resolution: {integrity: sha512-0kLAjs+xN5OjhTt/aUA6t48SfENSCKgGPfExADYTOo/UCn0ivxos9/anUVeSfg+L+2O9xkFxvJXIJfG+Q4sYSg==}
+  /@esbuild/win32-x64/0.17.5:
+    resolution: {integrity: sha512-XgA9qWRqby7xdYXuF6KALsn37QGBMHsdhmnpjfZtYxKxbTOwfnDM6MYi2WuUku5poNaX2n9XGVr20zgT/2QwCw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -1250,7 +1250,7 @@ packages:
       chokidar: 3.5.3
       cssnano: 5.1.14_postcss@8.4.21
       defu: 6.1.2
-      esbuild: 0.17.4
+      esbuild: 0.17.5
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       externality: 1.0.0
@@ -1272,7 +1272,7 @@ packages:
       ufo: 1.0.1
       unplugin: 1.0.1
       vite: 4.0.4
-      vite-node: 0.28.2
+      vite-node: 0.28.3
       vite-plugin-checker: 0.5.5_u77tqavq65p7wguz7tqx7wmxhe
       vue: 3.2.45
       vue-bundle-renderer: 1.0.0
@@ -1557,6 +1557,19 @@ packages:
     dependencies:
       rollup: 3.11.0
       slash: 4.0.0
+    dev: false
+
+  /@rollup/plugin-alias/4.0.3_rollup@3.12.1:
+    resolution: {integrity: sha512-ZuDWE1q4PQDhvm/zc5Prun8sBpLJy41DMptYrS6MhAy9s9kL/doN1613BWfEchGVfKxzliJ3BjbOPizXX38DbQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      rollup: 3.12.1
+      slash: 4.0.0
 
   /@rollup/plugin-commonjs/24.0.1_rollup@3.11.0:
     resolution: {integrity: sha512-15LsiWRZk4eOGqvrJyu3z3DaBu5BhXIMeWnijSRvd8irrrg9SHpQ1pH+BUK4H6Z9wL9yOxZJMTLU+Au86XHxow==}
@@ -1574,8 +1587,26 @@ packages:
       is-reference: 1.2.1
       magic-string: 0.27.0
       rollup: 3.11.0
+    dev: false
 
-  /@rollup/plugin-inject/5.0.3_rollup@3.11.0:
+  /@rollup/plugin-commonjs/24.0.1_rollup@3.12.1:
+    resolution: {integrity: sha512-15LsiWRZk4eOGqvrJyu3z3DaBu5BhXIMeWnijSRvd8irrrg9SHpQ1pH+BUK4H6Z9wL9yOxZJMTLU+Au86XHxow==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2_rollup@3.12.1
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 8.1.0
+      is-reference: 1.2.1
+      magic-string: 0.27.0
+      rollup: 3.12.1
+
+  /@rollup/plugin-inject/5.0.3_rollup@3.12.1:
     resolution: {integrity: sha512-411QlbL+z2yXpRWFXSmw/teQRMkXcAAC8aYTemc15gwJRpvEVDQwoe+N/HTFD8RFG8+88Bme9DK2V9CVm7hJdA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1584,10 +1615,10 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.11.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.12.1
       estree-walker: 2.0.2
       magic-string: 0.27.0
-      rollup: 3.11.0
+      rollup: 3.12.1
 
   /@rollup/plugin-json/6.0.0_rollup@3.11.0:
     resolution: {integrity: sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==}
@@ -1600,6 +1631,19 @@ packages:
     dependencies:
       '@rollup/pluginutils': 5.0.2_rollup@3.11.0
       rollup: 3.11.0
+    dev: false
+
+  /@rollup/plugin-json/6.0.0_rollup@3.12.1:
+    resolution: {integrity: sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2_rollup@3.12.1
+      rollup: 3.12.1
 
   /@rollup/plugin-node-resolve/15.0.1_rollup@3.11.0:
     resolution: {integrity: sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==}
@@ -1617,6 +1661,24 @@ packages:
       is-module: 1.0.0
       resolve: 1.22.1
       rollup: 3.11.0
+    dev: false
+
+  /@rollup/plugin-node-resolve/15.0.1_rollup@3.12.1:
+    resolution: {integrity: sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2_rollup@3.12.1
+      '@types/resolve': 1.20.2
+      deepmerge: 4.2.2
+      is-builtin-module: 3.2.0
+      is-module: 1.0.0
+      resolve: 1.22.1
+      rollup: 3.12.1
 
   /@rollup/plugin-replace/5.0.2_rollup@3.11.0:
     resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
@@ -1631,7 +1693,20 @@ packages:
       magic-string: 0.27.0
       rollup: 3.11.0
 
-  /@rollup/plugin-terser/0.4.0_rollup@3.11.0:
+  /@rollup/plugin-replace/5.0.2_rollup@3.12.1:
+    resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2_rollup@3.12.1
+      magic-string: 0.27.0
+      rollup: 3.12.1
+
+  /@rollup/plugin-terser/0.4.0_rollup@3.12.1:
     resolution: {integrity: sha512-Ipcf3LPNerey1q9ZMjiaWHlNPEHNU/B5/uh9zXLltfEQ1lVSLLeZSgAtTPWGyw8Ip1guOeq+mDtdOlEj/wNxQw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1640,12 +1715,12 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.11.0
+      rollup: 3.12.1
       serialize-javascript: 6.0.1
       smob: 0.0.6
       terser: 5.16.1
 
-  /@rollup/plugin-wasm/6.1.2_rollup@3.11.0:
+  /@rollup/plugin-wasm/6.1.2_rollup@3.12.1:
     resolution: {integrity: sha512-YdrQ7zfnZ54Y+6raCev3tR1PrhQGxYKSTajGylhyP0oBacouuNo6KcNCk+pYKw9M98jxRWLFFca/udi76IDXzg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1654,7 +1729,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.11.0
+      rollup: 3.12.1
 
   /@rollup/pluginutils/4.2.1:
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
@@ -1689,6 +1764,20 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.11.0
+
+  /@rollup/pluginutils/5.0.2_rollup@3.12.1:
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.0
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 3.12.1
 
   /@sindresorhus/is/4.6.0:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
@@ -3531,34 +3620,34 @@ packages:
       '@esbuild/win32-ia32': 0.16.17
       '@esbuild/win32-x64': 0.16.17
 
-  /esbuild/0.17.4:
-    resolution: {integrity: sha512-zBn9MeCwT7W5F1a3lXClD61ip6vQM+H8Msb0w8zMT4ZKBpDg+rFAraNyWCDelB/2L6M3g6AXHPnsyvjMFnxtFw==}
+  /esbuild/0.17.5:
+    resolution: {integrity: sha512-Bu6WLCc9NMsNoMJUjGl3yBzTjVLXdysMltxQWiLAypP+/vQrf+3L1Xe8fCXzxaECus2cEJ9M7pk4yKatEwQMqQ==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.17.4
-      '@esbuild/android-arm64': 0.17.4
-      '@esbuild/android-x64': 0.17.4
-      '@esbuild/darwin-arm64': 0.17.4
-      '@esbuild/darwin-x64': 0.17.4
-      '@esbuild/freebsd-arm64': 0.17.4
-      '@esbuild/freebsd-x64': 0.17.4
-      '@esbuild/linux-arm': 0.17.4
-      '@esbuild/linux-arm64': 0.17.4
-      '@esbuild/linux-ia32': 0.17.4
-      '@esbuild/linux-loong64': 0.17.4
-      '@esbuild/linux-mips64el': 0.17.4
-      '@esbuild/linux-ppc64': 0.17.4
-      '@esbuild/linux-riscv64': 0.17.4
-      '@esbuild/linux-s390x': 0.17.4
-      '@esbuild/linux-x64': 0.17.4
-      '@esbuild/netbsd-x64': 0.17.4
-      '@esbuild/openbsd-x64': 0.17.4
-      '@esbuild/sunos-x64': 0.17.4
-      '@esbuild/win32-arm64': 0.17.4
-      '@esbuild/win32-ia32': 0.17.4
-      '@esbuild/win32-x64': 0.17.4
+      '@esbuild/android-arm': 0.17.5
+      '@esbuild/android-arm64': 0.17.5
+      '@esbuild/android-x64': 0.17.5
+      '@esbuild/darwin-arm64': 0.17.5
+      '@esbuild/darwin-x64': 0.17.5
+      '@esbuild/freebsd-arm64': 0.17.5
+      '@esbuild/freebsd-x64': 0.17.5
+      '@esbuild/linux-arm': 0.17.5
+      '@esbuild/linux-arm64': 0.17.5
+      '@esbuild/linux-ia32': 0.17.5
+      '@esbuild/linux-loong64': 0.17.5
+      '@esbuild/linux-mips64el': 0.17.5
+      '@esbuild/linux-ppc64': 0.17.5
+      '@esbuild/linux-riscv64': 0.17.5
+      '@esbuild/linux-s390x': 0.17.5
+      '@esbuild/linux-x64': 0.17.5
+      '@esbuild/netbsd-x64': 0.17.5
+      '@esbuild/openbsd-x64': 0.17.5
+      '@esbuild/sunos-x64': 0.17.5
+      '@esbuild/win32-arm64': 0.17.5
+      '@esbuild/win32-ia32': 0.17.5
+      '@esbuild/win32-x64': 0.17.5
 
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -6018,22 +6107,22 @@ packages:
       type-fest: 2.19.0
     dev: true
 
-  /nitropack/2.1.0:
-    resolution: {integrity: sha512-8iA2oM9Ep1Xo+cgsRHWMMcqOW8DR5b0fyD6X0bAfvl0DMygP4/879X10EqATPJtrhaIU8AMW7MmALsnd1SOsOQ==}
+  /nitropack/2.1.1:
+    resolution: {integrity: sha512-fjjP0VlymKaPrLOsKF7L+Uq04D1e0XpM7V+TxQ1YYhygGZ4X13RJN7uwIY2R/2gluy3Jbv3/LtOuTopeMNRR5Q==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     hasBin: true
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.0
       '@netlify/functions': 1.4.0
-      '@rollup/plugin-alias': 4.0.3_rollup@3.11.0
-      '@rollup/plugin-commonjs': 24.0.1_rollup@3.11.0
-      '@rollup/plugin-inject': 5.0.3_rollup@3.11.0
-      '@rollup/plugin-json': 6.0.0_rollup@3.11.0
-      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.11.0
-      '@rollup/plugin-replace': 5.0.2_rollup@3.11.0
-      '@rollup/plugin-terser': 0.4.0_rollup@3.11.0
-      '@rollup/plugin-wasm': 6.1.2_rollup@3.11.0
-      '@rollup/pluginutils': 5.0.2_rollup@3.11.0
+      '@rollup/plugin-alias': 4.0.3_rollup@3.12.1
+      '@rollup/plugin-commonjs': 24.0.1_rollup@3.12.1
+      '@rollup/plugin-inject': 5.0.3_rollup@3.12.1
+      '@rollup/plugin-json': 6.0.0_rollup@3.12.1
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.12.1
+      '@rollup/plugin-replace': 5.0.2_rollup@3.12.1
+      '@rollup/plugin-terser': 0.4.0_rollup@3.12.1
+      '@rollup/plugin-wasm': 6.1.2_rollup@3.12.1
+      '@rollup/pluginutils': 5.0.2_rollup@3.12.1
       '@vercel/nft': 0.22.6
       archiver: 5.3.1
       c12: 1.1.0
@@ -6044,7 +6133,7 @@ packages:
       defu: 6.1.2
       destr: 1.2.2
       dot-prop: 7.2.0
-      esbuild: 0.17.4
+      esbuild: 0.17.5
       escape-string-regexp: 5.0.0
       etag: 1.8.1
       fs-extra: 11.1.0
@@ -6069,8 +6158,8 @@ packages:
       pkg-types: 1.0.1
       pretty-bytes: 6.0.0
       radix3: 1.0.0
-      rollup: 3.11.0
-      rollup-plugin-visualizer: 5.9.0_rollup@3.11.0
+      rollup: 3.12.1
+      rollup-plugin-visualizer: 5.9.0_rollup@3.12.1
       scule: 1.0.0
       semver: 7.3.8
       serve-placeholder: 2.0.1
@@ -6078,8 +6167,8 @@ packages:
       source-map-support: 0.5.21
       std-env: 3.3.1
       ufo: 1.0.1
-      unenv: 1.0.2
-      unimport: 2.0.1_rollup@3.11.0
+      unenv: 1.0.3
+      unimport: 2.1.0_rollup@3.12.1
       unstorage: 1.0.1
     transitivePeerDependencies:
       - bufferutil
@@ -6278,7 +6367,7 @@ packages:
       knitwork: 1.0.0
       magic-string: 0.27.0
       mlly: 1.1.0
-      nitropack: 2.1.0
+      nitropack: 2.1.1
       nuxi: 3.1.1
       ofetch: 1.0.0
       ohash: 1.0.0
@@ -7649,6 +7738,22 @@ packages:
       source-map: 0.7.4
       yargs: 17.6.2
 
+  /rollup-plugin-visualizer/5.9.0_rollup@3.12.1:
+    resolution: {integrity: sha512-bbDOv47+Bw4C/cgs0czZqfm8L82xOZssk4ayZjG40y9zbXclNk7YikrZTDao6p7+HDiGxrN0b65SgZiVm9k1Cg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    peerDependencies:
+      rollup: 2.x || 3.x
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      open: 8.4.0
+      picomatch: 2.3.1
+      rollup: 3.12.1
+      source-map: 0.7.4
+      yargs: 17.6.2
+
   /rollup-pluginutils/2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
     dependencies:
@@ -7657,6 +7762,13 @@ packages:
 
   /rollup/3.11.0:
     resolution: {integrity: sha512-+uWPPkpWQ2H3Qi7sNBcRfhhHJyUNgBYhG4wKe5wuGRj2m55kpo+0p5jubKNBjQODyPe6tSBE3tNpdDwEisQvAQ==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  /rollup/3.12.1:
+    resolution: {integrity: sha512-t9elERrz2i4UU9z7AwISj3CQcXP39cWxgRWLdf4Tm6aKm1eYrqHIgjzXBgb67GNY1sZckTFFi0oMozh3/S++Ig==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -8408,6 +8520,14 @@ packages:
       node-fetch-native: 1.0.1
       pathe: 1.1.0
 
+  /unenv/1.0.3:
+    resolution: {integrity: sha512-4T+7NTvVEPE3wvvVDpV9rk/UNDOil0OboLzPqHT1/t88B/nwSs41ClQg/NeA/+UvYEVxf/6V+5Opk9SIrrkPvg==}
+    dependencies:
+      defu: 6.1.2
+      mime: 3.0.0
+      node-fetch-native: 1.0.1
+      pathe: 1.1.0
+
   /unhead/1.0.18:
     resolution: {integrity: sha512-lHuOvFcj7ijFM6ceRuPq1+0sOAap8fueJxf+SkuWtfm68oxuLP8ct3C3oRyMT/hyWjzfWgoaECmjmw5x2cHnpg==}
     dependencies:
@@ -8448,6 +8568,23 @@ packages:
     resolution: {integrity: sha512-hMeDspGrEcocahicTr0AQYUGes24FvJtOxk9QEjeEOGv+n1EdpsDiT6z8t209PWhemPg0T5w/ooTVhup2GdrFA==}
     dependencies:
       '@rollup/pluginutils': 5.0.2_rollup@3.11.0
+      escape-string-regexp: 5.0.0
+      fast-glob: 3.2.12
+      local-pkg: 0.4.3
+      magic-string: 0.27.0
+      mlly: 1.1.0
+      pathe: 1.1.0
+      pkg-types: 1.0.1
+      scule: 1.0.0
+      strip-literal: 1.0.0
+      unplugin: 1.0.1
+    transitivePeerDependencies:
+      - rollup
+
+  /unimport/2.1.0_rollup@3.12.1:
+    resolution: {integrity: sha512-GDVIxATluUquX8EqelT6DtnmnZaXGID1jsO9IXwlnxb0OIEqKAxTOnTlnGmHbseoGTh+ZC9kcNDaO18HYQj9KA==}
+    dependencies:
+      '@rollup/pluginutils': 5.0.2_rollup@3.12.1
       escape-string-regexp: 5.0.0
       fast-glob: 3.2.12
       local-pkg: 0.4.3
@@ -8670,8 +8807,8 @@ packages:
       vfile-message: 3.1.3
     dev: false
 
-  /vite-node/0.28.2:
-    resolution: {integrity: sha512-zyiJ3DLs9zXign4P2MD4PQk+7rdT+JkHukgmmS0KuImbCQ7WnCdea5imQVeT6OtUsBwsLztJxQODUsinVr91tg==}
+  /vite-node/0.28.3:
+    resolution: {integrity: sha512-uJJAOkgVwdfCX8PUQhqLyDOpkBS5+j+FdbsXoPVPDlvVjRkb/W/mLYQPSL6J+t8R0UV8tJSe8c9VyxVQNsDSyg==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,10 +11,10 @@ specifiers:
   '@nuxthq/studio': ^0.6.6
   '@nuxtjs/algolia': ^1.5.0
   '@nuxtjs/eslint-config-typescript': ^12.0.0
+  '@nuxtjs/plausible': ^0.2.0
   '@vueuse/nuxt': ^9.12.0
   eslint: ^8.33.0
   nuxt: 3.1.1
-  nuxt-plausible: ^0.1.2
   release-it: ^15.6.0
   typescript: ^4.9.5
   vue: ^3.2.45
@@ -33,9 +33,9 @@ devDependencies:
   '@docsearch/js': 3.3.2_2r467mdhb7mblpaox4bg7fatdi
   '@nuxtjs/algolia': 1.5.0_vue@3.2.45
   '@nuxtjs/eslint-config-typescript': 12.0.0_4vsywjlpuriuw3tl5oq6zy5a64
+  '@nuxtjs/plausible': 0.2.0
   eslint: 8.33.0
   nuxt: 3.1.1_4vsywjlpuriuw3tl5oq6zy5a64
-  nuxt-plausible: 0.1.2
   release-it: 15.6.0
   typescript: 4.9.5
   vue: 3.2.45
@@ -1378,6 +1378,18 @@ packages:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /@nuxtjs/plausible/0.2.0:
+    resolution: {integrity: sha512-mke+eW94PCca7zK0kNpNA9ULat5JCrBP2JUCmas6ZKpskU3+IaBv2OzWYzWJb/SsungfV9a/dukKbjAJeBTzhQ==}
+    dependencies:
+      '@nuxt/kit': 3.1.1
+      defu: 6.1.2
+      pathe: 1.1.0
+      plausible-tracker: 0.3.8
+    transitivePeerDependencies:
+      - rollup
       - supports-color
     dev: true
 
@@ -6235,19 +6247,6 @@ packages:
       - supports-color
       - vue
     dev: false
-
-  /nuxt-plausible/0.1.2:
-    resolution: {integrity: sha512-w3Flmonlb73L/IpPkkNfSuUgahXtmp/xyp33MWdqaxMUgwRAdXNZy+YNJyFUPZObp/yruZquisoMy0WLKfcCJQ==}
-    deprecated: Moved to @nuxtjs/plausible. Please use this package instead.
-    dependencies:
-      '@nuxt/kit': 3.1.1
-      defu: 6.1.2
-      pathe: 1.1.0
-      plausible-tracker: 0.3.8
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-    dev: true
 
   /nuxt/3.1.1_4vsywjlpuriuw3tl5oq6zy5a64:
     resolution: {integrity: sha512-GVdmV88lR01OX0slxTPyTzwQkge7fxNREkx2QW0Lo66fb6aHcJlRXzFMBCOTjas+Ncng6AalIyIiPREEteGKSg==}


### PR DESCRIPTION
### Prepares v2 release

@Atinux @bdrtsky  can you list what you would like to change for the default config of Docus v2?

I release 1.7.0 containing recent updates as 1.6.3 has been reported as breaking version.

I think we could profit from this v2 release to ship breaking changes on config defaults, but maybe should wait after vuejs.asmterdam?

---

- [ ] State on https://github.com/nuxt-themes/docus/pull/663?

- [ ] Get help on the error I get on the deployments 😬