### PR TITLE
fix: remove socials default key to enable sorting for end user

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -6,14 +6,7 @@ export default defineAppConfig({
 
     image: 'https://user-images.githubusercontent.com/904724/185365452-87b7ca7b-6030-4813-a2db-5e65c785bf88.png',
 
-    socials: {
-      twitter: '',
-      github: '',
-      facebook: '',
-      instagram: '',
-      youtube: '',
-      medium: ''
-    },
+    socials: {},
 
     layout: 'default',
 


### PR DESCRIPTION
fix #817 