### PR TITLE
fix: Allow children links in toc to close the toc

### DIFF
--- a/components/docs/DocsTocLinks.vue
+++ b/components/docs/DocsTocLinks.vue
@@ -30,6 +30,10 @@ function scrollToHeading (id: string) {
   router.push(`#${id}`)
   emit('move', id)
 }
+
+function childMove(id: string) {
+  emit('move', id)
+}
 </script>
 
 <template>
@@ -42,7 +46,7 @@ function scrollToHeading (id: string) {
       >
         {{ link.text }}
       </a>
-      <DocsTocLinks v-if="link.children" :links="link.children" />
+      <DocsTocLinks v-if="link.children" :links="link.children" @move="childMove($event)" />
     </li>
   </ul>
 </template>


### PR DESCRIPTION
This is for when the TOC is rendered on a small device.

Without this code, only first level links close the TOC when clicked.