### PR TITLE
fix: fix aside collapsed navigation

### DIFF
--- a/components/docs/DocsAsideTree.vue
+++ b/components/docs/DocsAsideTree.vue
@@ -24,11 +24,9 @@ const route = useRoute()
 const { config } = useDocus()
 
 const collapsedMap = useState(`docus-docs-aside-collapse-map-${props.parent?._path || '/'}`, () => {
-  if (props.level === 0) {
-    return {}
-  }
   return (props.links as any [])
     .filter(link => !!link.children)
+    .filter(link => link?.collapsed || route.path.includes(link._path))
     .reduce((map, link) => {
       map[link._path] = true
       return map
@@ -102,7 +100,7 @@ const hasNesting = computed(() => props.links.some((link: any) => link.children)
       </NuxtLink>
 
       <DocsAsideTree
-        v-show="!isCollapsed(link)"
+        v-show="isCollapsed(link)"
         v-if="link.children?.length && (max === null || level + 1 < max)"
         :links="link.children"
         :level="level + 1"

--- a/composables/useDocus.ts
+++ b/composables/useDocus.ts
@@ -35,7 +35,6 @@ export const useDocus = () => {
         } as typeof header,
         aside: {
           ...aside,
-          ...navKeyFromPath(route.path, 'aside', navigation.value || []),
           ...page.value?.aside
         } as typeof aside,
         footer: {


### PR DESCRIPTION
- avoid injection of { collapsed: true } value from `...navKeyFromPath(route.path, 'header', navigation.value || []),` of `useDocus()`
- collapse tree on active link