### PR TITLE
Fine tuning collapsed state

### DIFF
--- a/components/docs/DocsAsideTree.vue
+++ b/components/docs/DocsAsideTree.vue
@@ -47,7 +47,7 @@ const isCollapsed = (link: any) => {
     }
 
     // Check if aside.collapsed has been set in YML
-    if (link?.aside?.collapsed) { return link.aside.collapsed }
+    if ([true, false].includes(link?.aside?.collapsed)) { return link.aside.collapsed }
 
     // Return value grabbed from the link
     if (link?.collapsed) { return link?.collapsed }


### PR DESCRIPTION
The line before the PR was not working when `aside.collapsed` was set to `false`, because the `if` statement was evaluated to `false`. I don't know if it's clean, but it works.