### PR TITLE
fix: resolve link clickability in section center

### DIFF
--- a/components/app/AppHeader.vue
+++ b/components/app/AppHeader.vue
@@ -88,7 +88,8 @@ css({
       '&.center': {
         gridColumn: 'span 4 / span 4',
         justifyContent: 'center',
-        flex: '1'
+        flex: '1',
+        zIndex: '1'
       },
       '&.right': {
         display: 'flex',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13056429/227933719-fc1ec9ab-15d8-44ce-a3ad-854a95c739ae.png)
Depending on the documentation content ([nuxt-image for example](https://v1.image.nuxtjs.org/)), the nav links in `section center` can get behind the `section right`, this prevents them from being clickable on screens such 1920px wide.

A quick fix would be to add the `z-index: 1` to `section center`.