### PR TITLE
Prevent navKeyFromPath from overwriting Docus config

### DIFF
--- a/composables/useDocus.ts
+++ b/composables/useDocus.ts
@@ -35,7 +35,6 @@ export const useDocus = () => {
         } as typeof header,
         aside: {
           ...aside,
-          ...navKeyFromPath(route.path, 'aside', navigation.value || []),
           ...page.value?.aside
         } as typeof aside,
         footer: {


### PR DESCRIPTION
I think the global `docus.aside.collapsed` from `app.config.ts` should not be overwritten by the local navKeyFromPath return value, which is specific to `useroute()`. In the `DocsAsideTree` component, the value from the `config` returned by `useDocus()` is the default value for all the nodes that have no local `aside.collapsed`, and which have not been manually collapsed.

I think the original code implies this default value is overwritten by navKeyFromPath, and applied to all the nodes, which is not the correct behaviour ?

I opened an issue (https://github.com/nuxt-themes/docus/issues/868) but nobody answered, so I try to open a discussion here because I think there's a bug that needs to be solved. For now, I disabled my auto deploy because I need to build my website locally, with the modified `useDocus.ts` file.