### PR TITLE
Fix: 500/404 Error from a GitHub Source Content

### DIFF
--- a/components/docs/DocsPrevNext.vue
+++ b/components/docs/DocsPrevNext.vue
@@ -8,7 +8,7 @@ const directory = (link: any) => {
   const nav = navDirFromPath(link._path, navigation.value || [])
 
   if (nav && nav[0]) {
-    return nav[0]._path
+    return nav[0]?._path ?? ''
   } else {
     const dirs = link.split('/')
     const directory = dirs.length > 1 ? dirs[dirs.length - 2] : ''
@@ -20,7 +20,7 @@ const directory = (link: any) => {
 <template>
   <div v-if="prev || next" class="docs-prev-next">
     <NuxtLink
-      v-if="prev"
+      v-if="prev && prev._path"
       :to="prev._path"
       class="prev"
     >
@@ -36,7 +36,7 @@ const directory = (link: any) => {
     <span v-else />
 
     <NuxtLink
-      v-if="next"
+      v-if="next && next._path"
       :to="next._path"
       class="next"
     >


### PR DESCRIPTION
This PR fixes an error when opening the last page from a remote source. The error manifests as 500 in development mode and 404 error when the document site is generated. 

The Sidebar link for the last page is generated from cannot be accessed.

This is the error generated when clicking on the last page from a GitHub source in development mode.

<img width="1717" alt="Screenshot 2023-04-03 at 15 52 06" src="https://user-images.githubusercontent.com/13512173/229554511-738157ed-f692-4d53-bd73-2668ced87803.png">

This is the error when the last page from a GitHub source is opened from a static hosting.

<img width="1722" alt="Screenshot 2023-04-03 at 16 23 25" src="https://user-images.githubusercontent.com/13512173/229555158-0f25493d-fe2a-416a-96dc-92e384445d94.png">

Here is our `nuxt.config.ts`:

```ts
export default defineNuxtConfig({
  extends: "@nuxt-themes/docus",
  content: {
    sources: {
      cloud_backend: {
        prefix: "/cloud-backend",
        driver: "github",
        repo: "Cavai/Cloud-Backend",
        branch: "docs%23move_in_docs",
        dir: "docs",
        token: process.env.NUXT_GITHUB_TOKEN
      },
      cloud_frontend: {
        prefix: "/cloud-frontend",
        driver: "github",
        repo: "Cavai/Cloud-Frontend",
        branch: "docs__move_in_docs",
        dir: "docs",
        token: process.env.NUXT_GITHUB_TOKEN
      }
    },
  }
});

```
