### PR TITLE
Update package.json "License" added, fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
       ]
     }
   },
+  "license": "MIT",
   "release-it": {
     "npm": {
       "access": "public"


### PR DESCRIPTION
Fixing the warning from yarn run build:

```
miguelgargallo@host HOME p/docus-docs-starter (main)
$ yarn run build
yarn run v1.22.19
warning package.json: No license field
$ nuxi build .docs/
Nuxi 3.3.3                                                                  12:17:55
Nuxt 3.3.3 with Nitro 2.3.3                                                 12:17:55
```