### PR TITLE
fix(schema): extend logo types

### DIFF
--- a/nuxt.schema.ts
+++ b/nuxt.schema.ts
@@ -139,7 +139,10 @@ export default defineNuxtSchema({
          * Boolean to disable or use the `Logo.vue` component.
          *
          * String to be used as a name of a component.
+         * 
+         * Object that sets the light and dark logos.
          *
+         * @type {boolean|string|{dark: string, light: string}}
          * @example 'MyLogo'
          * @studioInput boolean
          */


### PR DESCRIPTION
Based on [AppHeaderLogo.vue](https://github.com/nuxt-themes/docus/blob/main/components/app/AppHeaderLogo.vue#L14-L35), you can set either a boolean, string or object for the logo. 

Currently, the generated type is only boolean, which breaks the type checking if you want to set a component (string) or the dark/light logo image URLs (object with strings).

This PR fixes this by setting the appropiate types. I have tested in the playground and works as expected. 

NOTE: I'm not sure what to do with `studioInput`. Does it break in Studio if you don't use a boolean?