### PR TITLE
fix: allow social icons to be a full URL

### DIFF
--- a/.starters/default/app.config.ts
+++ b/.starters/default/app.config.ts
@@ -4,8 +4,13 @@ export default defineAppConfig({
     description: 'The best place to start your documentation.',
     image: 'https://user-images.githubusercontent.com/904724/185365452-87b7ca7b-6030-4813-a2db-5e65c785bf88.png',
     socials: {
-      twitter: 'nuxtstudio',
-      github: 'nuxt-themes/docus'
+      twitter: 'nuxt_js',
+      github: 'nuxt-themes/docus',
+      nuxt: {
+        label: 'Nuxt',
+        icon: 'simple-icons:nuxtdotjs',
+        href: 'https://nuxt.com'
+      }
     },
     github: {
       dir: '.starters/default/content',
@@ -28,14 +33,6 @@ export default defineAppConfig({
       showLinkIcon: true,
       exclude: [],
       fluid: true
-    },
-    footer: {
-      iconLinks: [
-        {
-          href: 'https://nuxt.com',
-          icon: 'simple-icons:nuxtdotjs'
-        }
-      ]
     }
   }
 })

--- a/.starters/default/content/1.introduction/4.configuration.md
+++ b/.starters/default/content/1.introduction/4.configuration.md
@@ -22,8 +22,8 @@ export default defineAppConfig({
     url: 'http://docus.dev',
     image: '/social-card-preview.png',
     socials: {
-      twitter: '@docus_',
-      github: 'nuxtlabs/docus',
+      twitter: '@nuxt_js',
+      github: 'nuxt-themes/docus',
     },
     github: {
       root: 'content',

--- a/components/app/AppSocialIcons.vue
+++ b/components/app/AppSocialIcons.vue
@@ -10,7 +10,7 @@ const icons = computed<any>(() => {
         return value
       } else if (typeof value === 'string' && value && socials.includes(key)) {
         return {
-          href: value.startsWith('http') || value.startsWith('www') ? value : `https://${key}.com/${value}`,
+          href: /^https?:\/\/.test(value) ? value : `https://${key}.com/${value}`,
           icon: `fa-brands:${key}`,
           label: value,
           rel: 'noopener noreferrer'

--- a/components/app/AppSocialIcons.vue
+++ b/components/app/AppSocialIcons.vue
@@ -10,7 +10,7 @@ const icons = computed<any>(() => {
         return value
       } else if (typeof value === 'string' && value && socials.includes(key)) {
         return {
-          href: `https://${key}.com/${value}`,
+          href: value.startsWith('http') || value.startsWith('www') ? value : `https://${key}.com/${value}`,
           icon: `fa-brands:${key}`,
           label: value,
           rel: 'noopener noreferrer'

--- a/components/app/AppSocialIcons.vue
+++ b/components/app/AppSocialIcons.vue
@@ -10,7 +10,7 @@ const icons = computed<any>(() => {
         return value
       } else if (typeof value === 'string' && value && socials.includes(key)) {
         return {
-          href: /^https?:\/\/.test(value) ? value : `https://${key}.com/${value}`,
+          href: /^https?:\/\//.test(value) ? value : `https://${key}.com/${value}`,
           icon: `fa-brands:${key}`,
           label: value,
           rel: 'noopener noreferrer'


### PR DESCRIPTION
Hi there 👋 

This PR is to be able to enable the users to set a full URL in social icons. For example:

```js
socials: {
    github: "https://git.company.com",
},
```

Thank you very much for the incredible work! 🚀 