### PR TITLE
feat: added Github baseURL to allow Enterprise URL

### DIFF
--- a/components/docs/EditOnLink.vue
+++ b/components/docs/EditOnLink.vue
@@ -7,6 +7,14 @@ import { useAppConfig } from '#imports'
 export default defineComponent({
   props: {
     /**
+     * GitHub base URL.
+     */
+    baseUrl: {
+      type: String,
+      default: () => useAppConfig()?.docus?.github?.baseUrl || 'https://github.com',
+      required: false
+    },
+    /**
      * Repository owner.
      */
     owner: {
@@ -81,7 +89,7 @@ export default defineComponent({
     }
 
     const source = computed(() => {
-      let { repo, owner, branch, contentDir } = props
+      let { baseUrl, repo, owner, branch, contentDir } = props
       let prefix = ''
 
       // Resolve source from content sources
@@ -97,6 +105,7 @@ export default defineComponent({
         }
 
         if (source?.driver === 'github') {
+          baseUrl = source.baseUrl || props.baseUrl
           repo = source.repo || props.repo || ''
           owner = source.owner || props.owner || ''
           branch = source.branch || props.branch || 'main'
@@ -105,10 +114,10 @@ export default defineComponent({
         }
       }
 
-      return { repo, owner, branch, contentDir, prefix }
+      return { baseUrl, repo, owner, branch, contentDir, prefix }
     })
 
-    const base = computed(() => joinURL('https://github.com', `${source.value.owner}/${source.value.repo}`))
+    const base = computed(() => joinURL(`${source.value.baseUrl}/${source.value.owner}/${source.value.repo}`))
 
     const path = computed(() => {
       const dirParts: string[] = []

--- a/components/docs/EditOnLink.vue
+++ b/components/docs/EditOnLink.vue
@@ -105,7 +105,6 @@ export default defineComponent({
         }
 
         if (source?.driver === 'github') {
-          baseUrl = source.baseUrl || props.baseUrl
           repo = source.repo || props.repo || ''
           owner = source.owner || props.owner || ''
           branch = source.branch || props.branch || 'main'

--- a/nuxt.schema.ts
+++ b/nuxt.schema.ts
@@ -284,6 +284,12 @@ export default defineNuxtSchema({
        */
       github: {
         /**
+         * Base URL
+         *
+         * You can use this to link to GitHub Enterprise.
+         */
+        baseUrl: 'https://github.com',
+        /**
          * Directory
          *
          * Your GitHub repository root directory.


### PR DESCRIPTION
Hi there 👋 

The purpose of this PR is to allow the `EditOnLink` and future components to work with Github Enterprise URLs.

![CleanShot 2023-06-13 at 12 27 50](https://github.com/nuxt-themes/docus/assets/5109593/f15c92e5-cda4-48c2-9830-4c18b9176699)
_I've edited the component to show the URL just for the screenshot._

Thank you for the amazing work 🚀 