### PR TITLE
docs: update contributing in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ defineNuxtConfig({
 2. Install dependencies using `pnpm install --frozen-lockfile`
 3. Run `pnpm run prepare` to generate type stubs.
 4. Update the `extends` key in `.starters/default` to `../../` in order to use the local version of Docus.
-5. Use `pnpm run dev` to start [docs](./docs) or use `pnpm run play` to start [playground](./playground) in development mode.
+5. Use `pnpm run dev` to start [default starter](./.starters/default)
 6. Do not commit any change in `.starters/default` since its your playground.
 
 ## License 📎

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ defineNuxtConfig({
 1. Clone this repository
 2. Install dependencies using `pnpm install --frozen-lockfile`
 3. Run `pnpm run prepare` to generate type stubs.
-4. Use `pnpm run dev` to start [docs](./docs) or use `pnpm run play` to start [playground](./playground) in development mode.
+4. Update the `extends` key in `.starters/default` to `../../` in order to use the local version of Docus.
+5. Use `pnpm run dev` to start [docs](./docs) or use `pnpm run play` to start [playground](./playground) in development mode.
+6. Do not commit any change in `.starters/default` since its your playground.
 
 ## License 📎
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,8 @@ defineNuxtConfig({
 1. Clone this repository
 2. Install dependencies using `pnpm install --frozen-lockfile`
 3. Run `pnpm run prepare` to generate type stubs.
-4. Update the `extends` key in `.starters/default` to `../../` in order to use the local version of Docus.
-5. Use `pnpm run dev` to start [default starter](./.starters/default)
-6. Do not commit any change in `.starters/default` since its your playground.
+4. Use `pnpm run dev` to start [default starter](./.starters/default). You can edit the module because pnpm workspace links it with the default starter.
+5. Do not commit any change in `.starters/default` since its your playground.
 
 ## License 📎
 


### PR DESCRIPTION
In order to preview change using the command `npm run dev`, we need to extend local Docus.