### PR TITLE
fix: fuse expects array not string

### DIFF
--- a/components/app/AppSearch.vue
+++ b/components/app/AppSearch.vue
@@ -31,7 +31,7 @@ const { meta_K, Escape } = useMagicKeys()
 
 const { data: files } = await useLazyAsyncData<DocusSearchResult[]>(
   'search-api',
-  () => $fetch('/api/search')
+  () => $fetch('/api/search', { parseResponse: JSON.parse })
 )
 
 const { results } = useFuse<DocusSearchResult>(


### PR DESCRIPTION
Fixes #949

At the moment new docus projects are breaking when you deploy, the reason is because we are feeding `useFuse` a string instead of an array.

You can see the root of the error here: https://github.com/krisk/Fuse/blob/f507e9f19ff022c13e4517ecff3e7a72ee2688ee/src/tools/FuseIndex.js#L38-L47

The `$fetch` to `/api/search` is not parsing the array, adding `{ parseResponse: JSON.parse }` fixes this issue.

---

Steps to reproduce error on a brand new project:

```bash
npx nuxi@latest init docs -t themes/docus 
cd docs
npm install
npm run build
node .output/server/index.mjs
```

![Kenny- 2023-07-26 at 12 50 02](https://github.com/nuxt-themes/docus/assets/6720728/5f299ad7-6fdf-4960-8f89-7dfc1dc600cd)
