### PR TITLE
fix: server api search handler

### DIFF
--- a/server/api/search.ts
+++ b/server/api/search.ts
@@ -22,7 +22,7 @@ export default defineEventHandler(async (event) => {
         // Only use `.md` files which are not drafts and has content
           return doc?._extension === 'md' &&
           doc?._draft === false &&
-          doc?._empty === false
+          !doc?._empty
         }
       )
       .map(


### PR DESCRIPTION
The `_empty` field in the parsed content is returning `undefined`. Adding a check for it.
Fixes nuxt-themes/docus#977