### PR TITLE
fix: separate type imports

### DIFF
--- a/components/app/AppSearch.vue
+++ b/components/app/AppSearch.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { useFuse, UseFuseOptions } from '@vueuse/integrations/useFuse'
+import { useFuse } from '@vueuse/integrations/useFuse'
 import { useFocusTrap } from '@vueuse/integrations/useFocusTrap'
 import { useMagicKeys } from '@vueuse/core'
+import type { UseFuseOptions } from '@vueuse/integrations/useFuse'
 
 const props = defineProps({
   fuse: {


### PR DESCRIPTION
Resolves: https://github.com/nuxt-themes/docus/issues/996

Nuxt 3.8.0 changed typescript defaults to use explicit type imports. This PR makes docus ready for this change