### PR TITLE
docs: minor typo

### DIFF
--- a/.starters/default/content/1.introduction/3.writing-pages.md
+++ b/.starters/default/content/1.introduction/3.writing-pages.md
@@ -2,7 +2,7 @@
 
 Docus is made to let you write all your content in Markdown and Vue components with the MDC syntax.
 
-Each Markdown pages in the `content/` folder will be mapped to a route.
+Each Markdown page in the `content/` folder will be mapped to a route.
 
 | File                     | Generated route       |
 | ------------------------ | :-------------------- |


### PR DESCRIPTION
Fix for minor typo: "page" not "pages" on 3.writing-pages.md