### PR TITLE
Fix dis-alignment of Prev-Next buttons when TOC is open [DocsPrevNext.vue]

### DIFF
--- a/components/docs/DocsPrevNext.vue
+++ b/components/docs/DocsPrevNext.vue
@@ -71,6 +71,7 @@ css({
   '.docs-prev-next': {
     display: 'flex',
     flexDirection: 'column',
+    flex-wrap: 1,
     justifyContent: 'space-between',
     gap: '{space.3}',
     '@sm': {
@@ -83,6 +84,7 @@ css({
       padding: '{space.3}',
       border: '1px solid {elements.border.primary.static}',
       borderRadius: '{radii.md}',
+      flex-grow: 1,
       '&:hover': {
         backgroundColor: '{color.gray.50}',
         borderColor: '{color.gray.50}',


### PR DESCRIPTION
Before:
<img width="840" alt="image" src="https://github.com/user-attachments/assets/e01317bc-f0fd-45ea-bf50-24eac431b85d" />

After: 
<img width="914" alt="image" src="https://github.com/user-attachments/assets/b50846a0-1b3a-4eb2-b493-083eaa8b80c0" />
