### PR TITLE
fix: stop forcefully disabling prose by default

### DIFF
--- a/.starters/default/content/index.md
+++ b/.starters/default/content/index.md
@@ -22,8 +22,8 @@ Docus brings the best of the Nuxt ecosystem into one CLI.
   size: xl
   to: /getting-started/installation
   trailing-icon: i-lucide-arrow-right
+  label: Get started
   ---
-  Get started
   :::
 
   :::u-button
@@ -33,8 +33,8 @@ Docus brings the best of the Nuxt ecosystem into one CLI.
   size: xl
   to: https://github.com/nuxt-ui-pro/docus
   variant: outline
+  label: Star on GitHub
   ---
-  Star on GitHub
   :::
 ::
 

--- a/.starters/i18n/content/en/index.md
+++ b/.starters/i18n/content/en/index.md
@@ -22,8 +22,8 @@ Docus brings the best of the Nuxt ecosystem into one CLI.
   size: xl
   to: /en/getting-started/installation
   trailing-icon: i-lucide-arrow-right
+  label: Get started
   ---
-  Get started
   :::
 
   :::u-button
@@ -33,8 +33,8 @@ Docus brings the best of the Nuxt ecosystem into one CLI.
   size: xl
   to: https://github.com/nuxt-ui-pro/docus
   variant: outline
+  label: Star on GitHub
   ---
-  Star on GitHub
   :::
 ::
 

--- a/.starters/i18n/content/fr/index.md
+++ b/.starters/i18n/content/fr/index.md
@@ -20,8 +20,8 @@ Docus rassemble le meilleur de l'écosystème Nuxt en une seule CLI.
   size: xl
   to: /fr/getting-started/installation
   trailing-icon: i-lucide-arrow-right
+  label: Commencer
   ---
-  Commencer
   :::
 
   :::u-button
@@ -31,8 +31,8 @@ Docus rassemble le meilleur de l'écosystème Nuxt en une seule CLI.
   size: xl
   to: https://github.com/nuxt-ui-pro/docus
   variant: outline
+  label: Étoile sur GitHub
   ---
-  Étoile sur GitHub
   :::
 ::
 

--- a/docs/content/en/2.concepts/5.customization.md
+++ b/docs/content/en/2.concepts/5.customization.md
@@ -26,8 +26,8 @@ color: neutral
 icon: i-lucide-code-xml
 to: https://github.com/nuxtlabs/docus/blob/main/layer/app/components/app/AppHeaderLogo.vue
 variant: link
+label: Default component code
 ---
-Default component code
 ::
 
 ### `AppHeaderCTA`
@@ -55,8 +55,8 @@ color: neutral
 icon: i-lucide-code-xml
 to: https://github.com/nuxtlabs/docus/blob/main/layer/app/components/app/AppHeaderCenter.vue
 variant: link
+label: Default component code
 ---
-Default component code
 ::
 
 ### `AppHeaderBody`
@@ -71,8 +71,8 @@ color: neutral
 icon: i-lucide-code-xml
 to: https://github.com/nuxtlabs/docus/blob/main/layer/app/components/app/AppHeaderBody.vue
 variant: link
+label: Default component code
 ---
-Default component code
 ::
 
 ## App Footer
@@ -91,8 +91,8 @@ color: neutral
 icon: i-lucide-code-xml
 to: https://github.com/nuxtlabs/docus/blob/main/layer/app/components/app/AppFooterLeft.vue
 variant: link
+label: Default component code
 ---
-Default component code
 ::
 
 ### `AppFooterRight`
@@ -107,8 +107,8 @@ color: neutral
 icon: i-lucide-code-xml
 to: https://github.com/nuxtlabs/docus/blob/main/layer/app/components/app/AppFooterRight.vue
 variant: link
+label: Default component code
 ---
-Default component code
 ::
 
 ## Docs
@@ -133,8 +133,8 @@ color: neutral
 icon: i-lucide-code-xml
 to: https://github.com/nuxtlabs/docus/blob/main/layer/app/components/docs/DocsPageHeaderLinks.vue
 variant: link
+label: Default component code
 ---
-Default component code
 ::
 
 ### `DocsAsideRightBottom`
@@ -149,8 +149,8 @@ color: neutral
 icon: i-lucide-code-xml
 to: https://github.com/nuxtlabs/docus/blob/main/layer/app/components/docs/DocsAsideRightBottom.vue
 variant: link
+label: Default component code
 ---
-Default component code
 ::
 
 ### `DocsAsideLeftTop`
@@ -178,6 +178,6 @@ color: neutral
 icon: i-lucide-code-xml
 to: https://github.com/nuxtlabs/docus/blob/main/layer/app/components/docs/DocsAsideLeftBody.vue
 variant: link
+label: Default component code
 ---
-Default component code
 ::

--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -22,8 +22,8 @@ Docus brings the best of the Nuxt ecosystem.
   size: xl
   to: en/getting-started/installation
   trailing-icon: i-lucide-arrow-right
+  label: Get started
   ---
-  Get started
   :::
 
   :::u-button
@@ -33,13 +33,18 @@ Docus brings the best of the Nuxt ecosystem.
   size: xl
   to: https://github.com/nuxtlabs/docus
   variant: outline
+  label: Star on GitHub
   ---
-  Star on GitHub
   :::
 
 #headline
-  :::u-button{size="sm" to="/en/getting-started/migration" variant="outline"}
-  Docus v4 →
+  :::u-button
+  ---
+  size: sm
+  variant: outline
+  to: /en/getting-started/migration
+  label: Docus v4 →
+  ---
   :::
 ::
 

--- a/docs/content/fr/2.concepts/5.customization.md
+++ b/docs/content/fr/2.concepts/5.customization.md
@@ -25,8 +25,8 @@ color: neutral
 icon: i-lucide-code-xml
 to: https://github.com/nuxtlabs/docus/blob/app/components/app/AppHeaderLogo.vue
 variant: link
+label: Code du composant par défaut
 ---
-Code du composant par défaut
 ::
 
 ### `AppHeaderCTA`
@@ -54,8 +54,8 @@ color: neutral
 icon: i-lucide-code-xml
 to: https://github.com/nuxtlabs/docus/blob/app/components/app/AppHeaderCenter.vue
 variant: link
+label: Code du composant par défaut
 ---
-Code du composant par défaut
 ::
 
 ### `AppHeaderBody`
@@ -70,8 +70,8 @@ color: neutral
 icon: i-lucide-code-xml
 to: https://github.com/nuxtlabs/docus/blob/app/components/app/AppHeaderBody.vue
 variant: link
+label: Code du composant par défaut
 ---
-Code du composant par défaut
 ::
 
 ## Docs
@@ -96,8 +96,8 @@ color: neutral
 icon: i-lucide-code-xml
 to: https://github.com/nuxtlabs/docus/blob/app/components/docs/DocsHeaderRight.vue
 variant: link
+label: Code du composant par défaut
 ---
-Code du composant par défaut
 ::
 
 ### `DocsAsideRightBottom`
@@ -112,8 +112,8 @@ color: neutral
 icon: i-lucide-code-xml
 to: https://github.com/nuxtlabs/docus/blob/app/components/docs/DocsAsideRightBottom.vue
 variant: link
+label: Code du composant par défaut
 ---
-Code du composant par défaut
 ::
 
 ### `DocsAsideLeftTop`

--- a/docs/content/fr/index.md
+++ b/docs/content/fr/index.md
@@ -20,8 +20,8 @@ Docus intègre le meilleur de l’écosystème Nuxt.
   size: xl
   to: /fr/getting-started/installation
   trailing-icon: i-lucide-arrow-right
+  label: Commencer
   ---
-  Commencer
   :::
 
   :::u-button
@@ -31,13 +31,18 @@ Docus intègre le meilleur de l’écosystème Nuxt.
   size: xl
   to: https://github.com/nuxtlabs/docus
   variant: outline
+  label: Étoile sur GitHub
   ---
-  Étoile sur GitHub
   :::
 
 #headline
-  :::u-button{size="sm" to="/fr/getting-started/migration" variant="outline"}
-  Docus v4 →
+  :::u-button
+  ---
+  size: sm
+  variant: outline
+  to: /fr/getting-started/migration
+  label: Docus v4 →
+  ---
   :::
 ::
 

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -25,5 +25,4 @@ export default defineNuxtConfig({
       description: 'Write beautiful docs with Markdown.',
     },
   },
-
 })

--- a/layer/app/templates/landing.vue
+++ b/layer/app/templates/landing.vue
@@ -42,6 +42,6 @@ else {
   <ContentRenderer
     v-if="page"
     :value="page"
-    :prose="prose || false"
+    :prose="prose"
   />
 </template>


### PR DESCRIPTION
Pointed out in https://github.com/nuxtlabs/docus/pull/1173#issuecomment-3254175013

Considering that mdc, content and ui modules all default to prose true by default the same should apply to docus IMO.

the ui issue described at https://github.com/nuxt/content/issues/3419 is more on a _improper_ use of mdc syntax, as the following should be applied/suggested for docus as well:

```diff
  :::u-button
  ---
  color: neutral
  size: xl
  to: en/getting-started/installation
  trailing-icon: i-lucide-arrow-right
+ label: Get started
  ---
- Get started
  :::
```

since we cannot forcefully use `MDCSlots` everywhere with related unwrapping, since developers and users might want their own logic

cc: @benjamincanac for helping me out