### PR TITLE
fix(types): annotate github app config type to allow false

### DIFF
--- a/layer/app/types/index.d.ts
+++ b/layer/app/types/index.d.ts
@@ -32,7 +32,7 @@ declare module 'nuxt/schema' {
       url: string
       branch: string
       rootDir?: string
-    }
+    } | false
   }
 }
 


### PR DESCRIPTION
Fixes the AppConfig type annotation to support the documented option to disable the GitHub integration.

See: https://docus.dev/en/concepts/configuration#github-integration

Before this change, setting `appConfig.github` to `false` caused a typescript error, preventing Nuxt to properly generate the AppConfig type in applications.
