### PR TITLE
fix(typescript): handle github config set to false

### DIFF
--- a/layer/app/components/app/AppFooterRight.vue
+++ b/layer/app/components/app/AppFooterRight.vue
@@ -8,7 +8,7 @@ const links = computed(() => [
     'target': '_blank',
     'aria-label': `${key} social link`,
   })),
-  appConfig.github?.url && {
+  appConfig.github && appConfig.github.url && {
     'icon': 'i-simple-icons-github',
     'to': appConfig.github.url,
     'target': '_blank',

--- a/layer/app/components/app/AppHeader.vue
+++ b/layer/app/components/app/AppHeader.vue
@@ -6,7 +6,7 @@ const site = useSiteConfig()
 
 const { localePath, isEnabled, locales } = useDocusI18n()
 
-const links = computed(() => appConfig.github?.url
+const links = computed(() => appConfig.github && appConfig.github.url
   ? [
       {
         'icon': 'i-simple-icons-github',

--- a/layer/app/pages/[[lang]]/[...slug].vue
+++ b/layer/app/pages/[[lang]]/[...slug].vue
@@ -46,16 +46,18 @@ defineOgImageComponent('Docs', {
   headline: headline.value,
 })
 
+const github = computed(() => appConfig.github ? appConfig.github : null)
+
 const editLink = computed(() => {
-  if (!appConfig.github) {
+  if (!github.value) {
     return
   }
 
   return [
-    appConfig.github.url,
+    github.value.url,
     'edit',
-    appConfig.github.branch,
-    appConfig.github.rootDir,
+    github.value.branch,
+    github.value.rootDir,
     'content',
     `${page.value?.stem}.${page.value?.extension}`,
   ].filter(Boolean).join('/')
@@ -92,7 +94,7 @@ const editLink = computed(() => {
 
       <USeparator>
         <div
-          v-if="editLink"
+          v-if="github"
           class="flex items-center gap-2 text-sm text-muted"
         >
           <UButton
@@ -109,7 +111,7 @@ const editLink = computed(() => {
           <UButton
             variant="link"
             color="neutral"
-            :to="`${appConfig.github.url}/issues/new/choose`"
+            :to="`${github.url}/issues/new/choose`"
             target="_blank"
             icon="i-lucide-alert-circle"
             :ui="{ leadingIcon: 'size-4' }"


### PR DESCRIPTION
Fixes a typescript error introduced by #1188 

```
Error: app/components/app/AppFooterRight.vue(11,21): error TS2339: Property 'url' does not exist on type 'false | { owner: string; name: string; url: string; branch: string; rootDir?: string | undefined; }'.
  Property 'url' does not exist on type 'false'.
Error: app/components/app/AppFooterRight.vue(13,28): error TS2339: Property 'url' does not exist on type 'false | { owner: string; name: string; url: string; branch: string; rootDir?: string | undefined; }'.
  Property 'url' does not exist on type 'false'.
Error: app/components/app/AppHeader.vue(9,48): error TS2339: Property 'url' does not exist on type 'false | { owner: string; name: string; url: string; branch: string; rootDir?: string | undefined; }'.
  Property 'url' does not exist on type 'false'.
Error: app/components/app/AppHeader.vue(13,32): error TS2339: Property 'url' does not exist on type 'false | { owner: string; name: string; url: string; branch: string; rootDir?: string | undefined; }'.
  Property 'url' does not exist on type 'false'.
Error: app/pages/[[lang]]/[...slug].vue(112,38): error TS2339: Property 'url' does not exist on type 'false | { owner: string; name: string; url: string; branch: string; rootDir?: string | undefined; }'.
  Property 'url' does not exist on type 'false'.
```