### PR TITLE
feat(layout): handle deeply nested content

### DIFF
--- a/layer/app/layouts/default.vue
+++ b/layer/app/layouts/default.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import type { ContentNavigationItem } from '@nuxt/content'
+import { flattenNavigation } from '../utils/navigation'
 
 const route = useRoute()
 const docsNavigation = inject<Ref<ContentNavigationItem[]>>('navigation')
-const docsLink = computed(() => docsNavigation?.value.flatMap(item => item.children || [item]) || [])
+const docsLink = computed(() => flattenNavigation(docsNavigation?.value))
 const isDocs = computed(() => docsLink.value.findIndex(item => item.path === route.path) !== -1)
 </script>
 

--- a/layer/app/utils/navigation.ts
+++ b/layer/app/utils/navigation.ts
@@ -1,0 +1,7 @@
+import type { ContentNavigationItem } from '@nuxt/content'
+
+export const flattenNavigation = (items?: ContentNavigationItem[]): ContentNavigationItem[] => items?.flatMap(
+  item => item.children
+    ? flattenNavigation(item.children)
+    : [item],
+) || []


### PR DESCRIPTION
This PR adds support for determining the layout to be used when items are deeply nested.

I mentioned this issue on the Nuxt UI 4 PR, but noticed it's actually caused by docus only flattening navigation items for one level. See https://github.com/nuxt-content/docus/pull/1173#issuecomment-3308009442