### PR TITLE
Fix markdown links when app.baseURL is set

### DIFF
--- a/layer/app/components/docs/DocsPageHeaderLinks.vue
+++ b/layer/app/components/docs/DocsPageHeaderLinks.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useClipboard } from '@vueuse/core'
+import { useRuntimeConfig } from '#imports'
 
 const route = useRoute()
 const appBaseURL = useRuntimeConfig().app?.baseURL || '/'


### PR DESCRIPTION
Setting `app.baseURL` in `nuxt.config.ts` currently breaks the raw markdown links.

This fixes this.