### PR TITLE
feat(i18n): add Indonesian (id) support

### DIFF
--- a/layer/app/components/LanguageSelect.vue
+++ b/layer/app/components/LanguageSelect.vue
@@ -29,6 +29,7 @@ function getEmojiFlag(locale: string): string {
     ur: 'pk', // Urdu -> Pakistan
     vi: 'vn', // Vietnamese -> Vietnam
     es: 'es', // Spanish -> Spain
+    id: 'id', // Indonesian -> Indonesia
   }
 
   const baseLanguage = locale.split('-')[0]?.toLowerCase() || locale

--- a/layer/i18n/locales/id.json
+++ b/layer/i18n/locales/id.json
@@ -1,0 +1,25 @@
+{
+	"common": {
+		"or": "atau",
+		"error": {
+			"title": "Halaman tidak ditemukan",
+			"description": "Kami minta maaf, halaman ini tidak dapat ditemukan."
+		},
+		"copied": "Berhasil disalin ke papan klip"
+	},
+	"docs": {
+		"copy": {
+			"page": "Salin halaman",
+			"link": "Salin halaman Markdown",
+			"view": "Lihat sebagai Markdown",
+			"gpt": "Buka di ChatGPT",
+			"claude": "Buka di Claude",
+			"mcp_url": "Salin URL Server MCP",
+			"mcp_add": "Tambah Server MCP"
+		},
+		"links": "Komunitas",
+		"toc": "Pada halaman ini",
+		"report": "Laporkan masalah",
+		"edit": "Ubah halaman ini"
+	}
+}


### PR DESCRIPTION
This PR adds Indonesian (id) language support to Docus.
- Added `layer/i18n/locales/id.json` with base translations.
- Updated `layer/app/components/LanguageSelect.vue` to include the Indonesian flag mapping.