### PR TITLE
feat: better LLM support  by using `/raw/**.md` links inside `llms.txt` 

### DIFF
--- a/layer/server/plugins/docus-llms.ts
+++ b/layer/server/plugins/docus-llms.ts
@@ -1,0 +1,18 @@
+import { withoutBase, withBase } from 'ufo'
+import type { NitroApp } from 'nitropack/types'
+import { defineNitroPlugin } from '#imports'
+
+export default defineNitroPlugin((nitroApp: NitroApp) => {
+  // @ts-expect-error - typecheck does not detect llms:generate
+  nitroApp.hooks.hook('llms:generate', async (_, options) => {
+    for (const section of options.sections) {
+      if (section.contentCollection !== 'docs' && !section.contentCollection?.startsWith('docs')) {
+        continue
+      }
+
+      for (const link of section.links) {
+        link.href = withBase(`/raw${withoutBase(link.href, options.domain)}.md`, options.domain)
+      }
+    }
+  })
+})


### PR DESCRIPTION
> Would reduce the amount of tokens of the crawlers

This PR listen to `llms:generate` hook and rewrite documents links with raw-md links.

Note: raw-md is a Docus feature and should be handle inside Docus.