### PR TITLE
fix(layer): enhance sitemap generation, exclude navigation files

### DIFF
--- a/docs/content/en/2.concepts/3.configuration.md
+++ b/docs/content/en/2.concepts/3.configuration.md
@@ -118,16 +118,10 @@ This page won't appear in the sitemap.
 
 #### Site URL
 
-For proper sitemap URLs, set the `NUXT_PUBLIC_SITE_URL` environment variable or configure it in your `nuxt.config.ts`:
+For proper sitemap URLs, set the `NUXT_SITE_URL` environment variable:
 
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  runtimeConfig: {
-    public: {
-      siteUrl: 'https://your-site.com'
-    }
-  }
-})
+```bash
+NUXT_SITE_URL=https://your-site.com
 ```
 
 ## Header

--- a/docs/content/fr/2.concepts/3.configuration.md
+++ b/docs/content/fr/2.concepts/3.configuration.md
@@ -118,16 +118,10 @@ Cette page n'apparaîtra pas dans le sitemap.
 
 #### URL du site
 
-Pour des URLs de sitemap correctes, définissez la variable d'environnement `NUXT_PUBLIC_SITE_URL` ou configurez-la dans votre `nuxt.config.ts` :
+Pour des URLs de sitemap correctes, définissez la variable d'environnement `NUXT_SITE_URL` :
 
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  runtimeConfig: {
-    public: {
-      siteUrl: 'https://votre-site.com'
-    }
-  }
-})
+```bash
+NUXT_SITE_URL=https://votre-site.com
 ```
 
 ## En-tête

--- a/layer/server/routes/sitemap.xml.ts
+++ b/layer/server/routes/sitemap.xml.ts
@@ -1,9 +1,10 @@
 import { queryCollection } from '@nuxt/content/server'
 import { getAvailableLocales, getCollectionsToQuery } from '../utils/content'
+import { inferSiteURL } from '../../utils/meta'
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig(event)
-  const siteUrl = (config.public.siteUrl as string) || (config.public.llms as Record<string, unknown>)?.domain as string || ''
+  const siteUrl = inferSiteURL() || ''
 
   const availableLocales = getAvailableLocales(config.public as Record<string, unknown>)
   const collections = getCollectionsToQuery(undefined, availableLocales)


### PR DESCRIPTION
This pull request updates how the site URL is configured for sitemap generation and improves the sitemap route logic. The environment variable for the site URL is simplified, and the sitemap now excludes navigation configuration files. Documentation is updated in both English and French to reflect these changes.

| Before | After |
|:---|:---|
| <img width="1938" height="1596" alt="CleanShot 2026-02-02 at 14 08 24@2x" src="https://github.com/user-attachments/assets/b142446c-6d16-4ada-b11c-6afcfa326799" /> | <img width="1928" height="1252" alt="CleanShot 2026-02-02 at 14 34 15@2x" src="https://github.com/user-attachments/assets/37ecfcc4-abc8-47b7-98a9-ac429f3af9de" /> |