### PR TITLE
fix: [1269] if github is disabled do not show separator

### DIFF
--- a/layer/app/pages/[[lang]]/[...slug].vue
+++ b/layer/app/pages/[[lang]]/[...slug].vue
@@ -99,9 +99,8 @@ addPrerenderPath(`/raw${route.path}.md`)
         :value="page"
       />
 
-      <USeparator>
+      <USeparator v-if="github">
         <div
-          v-if="github"
           class="flex items-center gap-2 text-sm text-muted"
         >
           <UButton


### PR DESCRIPTION
simple fix for [#1269](https://github.com/nuxt-content/docus/issues/1269)