### PR TITLE
fix: don't use @theme static for priority

### DIFF
--- a/docs/app/assets/css/main.css
+++ b/docs/app/assets/css/main.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 @import "@nuxt/ui";
 
-@theme static {
+@theme {
   --font-sans: 'Public Sans', sans-serif;
   --ui-container: 90rem;
 }

--- a/docs/content/en/2.concepts/4.theme.md
+++ b/docs/content/en/2.concepts/4.theme.md
@@ -24,7 +24,7 @@ This way you can override your theme:
 @import "tailwindcss";
 @import "@nuxt/ui";
 
-@theme static {
+@theme {
   --font-sans: 'Public Sans', sans-serif;
 
   --breakpoint-3xl: 1920px;

--- a/docs/content/fr/2.concepts/4.theme.md
+++ b/docs/content/fr/2.concepts/4.theme.md
@@ -24,7 +24,7 @@ De cette façon, vous pouvez surcharger votre thème :
 @import "tailwindcss";
 @import "@nuxt/ui";
 
-@theme static {
+@theme {
   --font-sans: 'Public Sans', sans-serif;
 
   --breakpoint-3xl: 1920px;

--- a/skills/create-docs/SKILL.md
+++ b/skills/create-docs/SKILL.md
@@ -339,7 +339,7 @@ Create `app/assets/css/main.css`:
 @import "tailwindcss";
 @import "@nuxt/ui";
 
-@theme static {
+@theme {
   /* Custom font */
   --font-sans: 'Inter', sans-serif;
 


### PR DESCRIPTION
The default 80rem container was not applied because of this, using `@theme` without `static` fixes it