### PR TITLE
fix(mcp): derive Docus MCP page URLs from request origin

### DIFF
--- a/layer/server/mcp/tools/get-page.ts
+++ b/layer/server/mcp/tools/get-page.ts
@@ -24,7 +24,7 @@ WORKFLOW: This tool returns the complete page content including title, descripti
   handler: async ({ path }) => {
     const event = useEvent()
     const config = useRuntimeConfig(event).public
-    const siteUrl = import.meta.dev ? 'http://localhost:3000' : inferSiteURL()
+    const siteUrl = getRequestURL(event).origin || inferSiteURL()
 
     const availableLocales = getAvailableLocales(config)
     const collectionName = config.i18n?.locales

--- a/layer/server/mcp/tools/list-pages.ts
+++ b/layer/server/mcp/tools/list-pages.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { queryCollection } from '@nuxt/content/server'
 import type { Collections } from '@nuxt/content'
 import { getCollectionsToQuery, getAvailableLocales } from '../../utils/content'
+import { inferSiteURL } from '../../../utils/meta'
 
 export default defineMcpTool({
   description: `Lists all available documentation pages with their categories and basic information.
@@ -30,7 +31,7 @@ OUTPUT: Returns a structured list with:
     const event = useEvent()
     const config = useRuntimeConfig(event).public
 
-    const siteUrl = import.meta.dev ? 'http://localhost:3000' : getRequestURL(event).origin
+    const siteUrl = getRequestURL(event).origin || inferSiteURL()
     const availableLocales = getAvailableLocales(config)
     const collections = getCollectionsToQuery(locale, availableLocales)
 


### PR DESCRIPTION
This makes the built-in MCP documentation tools return request-derived page URLs instead of hardcoded localhost URLs, so custom dev ports, previews, tunnels, and proxies work correctly.

related https://github.com/nuxt-modules/mcp-toolkit/pull/143