### PR TITLE
feat: add AppHeaderLeft component

### DIFF
--- a/docs/content/en/2.concepts/5.customization.md
+++ b/docs/content/en/2.concepts/5.customization.md
@@ -31,6 +31,20 @@ variant: link
 Default component code
 ::
 
+### `AppHeaderLeft`
+
+The logo sits inside a default home link wrapper. If you want to change that link (URL, attributes) or the layout around `AppHeaderLogo`, override `components/AppHeaderLeft.vue` instead.
+
+::u-button
+---
+color: neutral
+icon: i-lucide-code-xml
+to: https://github.com/nuxt-content/docus/blob/main/layer/app/components/app/AppHeaderLeft.vue
+variant: link
+---
+Default component code
+::
+
 ### `AppHeaderCTA`
 
 To customize the call-to-action area in the header (for example, adding a “Get Started” button or external link), override the `components/AppHeaderCTA.vue` component.
@@ -97,7 +111,7 @@ You can customize different parts of the footer by overriding the following comp
 
 ### `AppFooterLeft`
 
-To replace the left side of the header, create the `components/AppFooterLeft.vue` file. Your component will replace the default one provided by Docus theme.
+To replace the left side of the footer, create the `components/AppFooterLeft.vue` file. Your component will replace the default one provided by Docus theme.
 
 ![App footer left visualisation](/documentation/app-footer-left.webp)
 

--- a/docs/content/fr/2.concepts/5.customization.md
+++ b/docs/content/fr/2.concepts/5.customization.md
@@ -31,6 +31,20 @@ variant: link
 Code du composant par défaut
 ::
 
+### `AppHeaderLeft`
+
+Le logo est placé dans un lien d'accueil par défaut. Pour modifier ce lien (URL, attributs) ou la mise en page autour de `AppHeaderLogo`, surchargez plutôt `components/AppHeaderLeft.vue`.
+
+::u-button
+---
+color: neutral
+icon: i-lucide-code-xml
+to: https://github.com/nuxt-content/docus/blob/main/layer/app/components/app/AppHeaderLeft.vue
+variant: link
+---
+Code du composant par défaut
+::
+
 ### `AppHeaderCTA`
 
 Pour personnaliser la zone d'appel à l'action dans l'en-tête (par exemple, ajouter un bouton « Commencer » ou un lien externe), surchargez le composant `components/AppHeaderCTA.vue`.

--- a/layer/app/components/app/AppHeader.vue
+++ b/layer/app/components/app/AppHeader.vue
@@ -27,13 +27,11 @@ const links = computed(() => appConfig.github && appConfig.github.url
   <UHeader
     :ui="{ center: 'flex-1' }"
     :class="{ 'flex flex-col': subNavigationMode === 'header' }"
-    :to="localePath('/')"
-    :title="appConfig.header?.title || site.name"
   >
     <AppHeaderCenter />
 
-    <template #title>
-      <AppHeaderLogo class="h-6 w-auto shrink-0" />
+    <template #left>
+      <AppHeaderLeft />
     </template>
 
     <template #right>

--- a/layer/app/components/app/AppHeaderLeft.vue
+++ b/layer/app/components/app/AppHeaderLeft.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+const appConfig = useAppConfig()
+const site = useSiteConfig()
+const { localePath } = useDocusI18n()
+
+const ariaLabel = appConfig.header?.title || site.name
+</script>
+
+<template>
+  <NuxtLink
+    :to="localePath('/')"
+    :aria-label="ariaLabel"
+  >
+    <AppHeaderLogo class="h-6 w-auto shrink-0" />
+  </NuxtLink>
+</template>


### PR DESCRIPTION
So people can customize more than just a logo, could be useful when you want to have a logo next to the main one for instance.