### PR TITLE
fix(assistant): use native keydown for escape blur

### DIFF
--- a/layer/modules/assistant/runtime/components/AssistantFloatingInput.vue
+++ b/layer/modules/assistant/runtime/components/AssistantFloatingInput.vue
@@ -42,15 +42,13 @@ const shortcuts = computed(() => ({
       inputRef.value?.inputRef?.focus()
     },
   },
-  escape: {
-    usingInput: true,
-    handler: () => {
-      inputRef.value?.inputRef?.blur()
-    },
-  },
 }))
 
 defineShortcuts(shortcuts)
+
+function onEscape() {
+  inputRef.value?.inputRef?.blur()
+}
 </script>
 
 <template>
@@ -82,6 +80,7 @@ defineShortcuts(shortcuts)
               trailing: 'pe-2',
             }"
             @keydown.enter.exact.prevent="handleSubmit"
+            @keydown.escape="onEscape"
           >
             <template #trailing>
               <div class="flex items-center gap-2">


### PR DESCRIPTION
- The `defineShortcuts` escape handler with `usingInput: true` was catching escape globally, which broke closing the search panel with escape.
- Replaced with a native `@keydown.escape` listener on the input so it only fires when the floating input is actually focused.
