### PR TITLE
docs: clarify index.vue placement for i18n setup

### DIFF
--- a/docs/content/en/2.concepts/2.edition.md
+++ b/docs/content/en/2.concepts/2.edition.md
@@ -32,7 +32,7 @@ The `MDC` syntax gives you the ability to use Vue components, including slots an
 
 ### `Vue` (custom)
 
-Since Docus is a layer, it allows you to fully customize your landing page by creating a Vue page at `app/pages/index.vue`. This gives you full control with Vue components, custom layouts, and advanced interactions.
+Since Docus is a layer, it allows you to fully customize your landing page by creating a Vue page at `app/pages/index.vue` (or `app/pages/[[lang]]/index.vue` for i18n setups). This gives you full control with Vue components, custom layouts, and advanced interactions.
 
 In this case, Docus:
 
@@ -41,8 +41,6 @@ In this case, Docus:
 
 ::note
 This automatic detection works for both single-language and multi-language (i18n) setups.
-
-Place your `index.vue` file at `app/pages/[[lang]]/index.vue`
 ::
 
 ### Components

--- a/docs/content/en/2.concepts/2.edition.md
+++ b/docs/content/en/2.concepts/2.edition.md
@@ -41,6 +41,8 @@ In this case, Docus:
 
 ::note
 This automatic detection works for both single-language and multi-language (i18n) setups.
+
+Place your `index.vue` file at `app/pages/[[lang]]/index.vue`
 ::
 
 ### Components

--- a/docs/content/fr/2.concepts/2.edition.md
+++ b/docs/content/fr/2.concepts/2.edition.md
@@ -28,7 +28,7 @@ Lorsqu'aucune page d'accueil personnalisée n'existe, Docus automatiquement:
 
 ### Page d'accueil Vue personnalisée
 
-Vous pouvez personnaliser votre page d'accueil en créant une page Vue à `app/pages/index.vue`. Cela vous donne un contrôle total avec les composants Vue, des layouts personnalisés et des interactions `js` avancées.
+Vous pouvez personnaliser votre page d'accueil en créant une page Vue à `app/pages/index.vue` (ou `app/pages/[[lang]]/index.vue` pour les configurations i18n). Cela vous donne un contrôle total avec les composants Vue, des layouts personnalisés et des interactions `js` avancées.
 
 **Lorsque vous créez** `app/pages/index.vue`, Docus :
 - Ne créera pas la collection `landing`


### PR DESCRIPTION
Clarify placement of index.vue for routing in Nuxt in i18n version.

For i18n versions, you need to add the [[lang]] prefix; otherwise, you'll get a 404 error.
app/pages/[[lang]]/index.vue 


<img width="889" height="444" alt="image" src="https://github.com/user-attachments/assets/d483d5ea-4da0-4328-8355-cf752d44d33d" />


**Fix:** 

Since Docus is a layer, it allows you to fully customize your landing page by creating a Vue page at `app/pages/index.vue` (or `app/pages/[[lang]]/index.vue` for i18n setups). This gives you full control with Vue components, custom layouts, and advanced interactions.
